### PR TITLE
29 Fix NA buyer/seller name index error

### DIFF
--- a/glue/flagging_script_glue/flagging_e894e5.py
+++ b/glue/flagging_script_glue/flagging_e894e5.py
@@ -1088,19 +1088,23 @@ def split_logic(words: str):
 
 def name_selector(tokens) -> str:
     """
-    Attempts to select the last name of a persons name based on number of tokens.
+    Attempts to select the last name of a person's name based on the number of tokens.
     Inputs:
-        tokens: name to be identified
+        tokens: list of strings where each string is a name token
     Outputs:
         'Empty Name' if name is empty.
         id (str): identified last name
     """
 
+    suffixes = ["jr", "sr", "ii", "iii", "iv", "v"]
+
     if tokens == "Empty Name" or tokens == []:
         return "Empty Name"
 
-    if tokens[-1] in ["jr", "sr", "ii", "iii", "iv", "v"]:
+    while tokens[-1] in suffixes:
         tokens = tokens[:-1]
+        if not tokens:  # Avoids IndexError if all tokens are removed.
+            return "Empty Name"
 
     id = tokens[-1]
 

--- a/glue/flagging_script_glue/flagging_e894e5.py
+++ b/glue/flagging_script_glue/flagging_e894e5.py
@@ -549,7 +549,6 @@ def get_sale_counts(dups: pd.DataFrame) -> pd.DataFrame:
         dups.pin.value_counts()
         .reset_index()
         .rename(columns={"count": "sv_sale_dup_counts"})
-        # .rename(columns={"index": "pin", "pin": "sv_sale_dup_counts"})
     )
 
     dups = pd.merge(dups, v_counts)

--- a/glue/flagging_script_glue/flagging_e894e5.py
+++ b/glue/flagging_script_glue/flagging_e894e5.py
@@ -1085,13 +1085,15 @@ def name_selector(tokens) -> str:
         'Empty Name' if name is empty.
         id (str): identified last name
     """
+    if not tokens:
+        return "Empty Name"
     if tokens == "Empty Name":
         return tokens
     # Ex: John Smith Jr
     if tokens[-1] in ["jr", "sr", "ii", "iii", "iv", "v"]:
         tokens = tokens[:-1]
     # Ex: John Smith
-    if len(tokens) == 2:
+    elif len(tokens) == 2:
         id = tokens[1]
     # John George Smith
     if len(tokens) == 3:

--- a/manual_flagging/initial_flagging.py
+++ b/manual_flagging/initial_flagging.py
@@ -112,6 +112,19 @@ metadata = cursor.description
 df_ingest = as_pandas(cursor)
 df = df_ingest
 
+
+buyer_na_dates = df_ingest[df_ingest["meta_sale_buyer_name"].isna()]["meta_sale_date"]
+
+print(buyer_na_dates.min())
+print(buyer_na_dates.max())
+
+
+seller_na_dates = df_ingest[df_ingest["meta_sale_seller_name"].isna()]["meta_sale_date"]
+
+print(seller_na_dates.min())
+print(seller_na_dates.max())
+
+
 df = df.astype({col[0]: flg.sql_type_to_pd_type(col[1]) for col in metadata})
 df["ptax_flag_original"].fillna(False, inplace=True)
 
@@ -154,8 +167,16 @@ df_res_flagged_updated = flg.group_size_adjustment(
 condo_iso_forest = inputs["iso_forest"].copy()
 condo_iso_forest.remove("sv_price_per_sqft")
 
+
+# Define the cutoff date
+cutoff_date = "2017-01-01"  # Replace 'YYYY-MM-DD' with the desired date in this format
+
+# Subset the DataFrame
+df_after_cutoff = df_condo_to_flag[df_condo_to_flag["meta_sale_date"] > cutoff_date]
+
+
 df_condo_flagged = flg_model.go(
-    df=df_condo_to_flag,
+    df=df_after_cutoff,
     groups=tuple(condo_stat_groups),
     iso_forest_cols=condo_iso_forest,
     dev_bounds=tuple(inputs["dev_bounds"]),

--- a/manual_flagging/initial_flagging.py
+++ b/manual_flagging/initial_flagging.py
@@ -112,19 +112,6 @@ metadata = cursor.description
 df_ingest = as_pandas(cursor)
 df = df_ingest
 
-
-buyer_na_dates = df_ingest[df_ingest["meta_sale_buyer_name"].isna()]["meta_sale_date"]
-
-print(buyer_na_dates.min())
-print(buyer_na_dates.max())
-
-
-seller_na_dates = df_ingest[df_ingest["meta_sale_seller_name"].isna()]["meta_sale_date"]
-
-print(seller_na_dates.min())
-print(seller_na_dates.max())
-
-
 df = df.astype({col[0]: flg.sql_type_to_pd_type(col[1]) for col in metadata})
 df["ptax_flag_original"].fillna(False, inplace=True)
 
@@ -167,16 +154,8 @@ df_res_flagged_updated = flg.group_size_adjustment(
 condo_iso_forest = inputs["iso_forest"].copy()
 condo_iso_forest.remove("sv_price_per_sqft")
 
-
-# Define the cutoff date
-cutoff_date = "2017-01-01"  # Replace 'YYYY-MM-DD' with the desired date in this format
-
-# Subset the DataFrame
-df_after_cutoff = df_condo_to_flag[df_condo_to_flag["meta_sale_date"] > cutoff_date]
-
-
 df_condo_flagged = flg_model.go(
-    df=df_after_cutoff,
+    df=df_condo_to_flag,
     groups=tuple(condo_stat_groups),
     iso_forest_cols=condo_iso_forest,
     dev_bounds=tuple(inputs["dev_bounds"]),

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -1088,19 +1088,23 @@ def split_logic(words: str):
 
 def name_selector(tokens) -> str:
     """
-    Attempts to select the last name of a persons name based on number of tokens.
+    Attempts to select the last name of a person's name based on the number of tokens.
     Inputs:
-        tokens: name to be identified
+        tokens: list of strings where each string is a name token
     Outputs:
         'Empty Name' if name is empty.
         id (str): identified last name
     """
 
+    suffixes = ["jr", "sr", "ii", "iii", "iv", "v"]
+
     if tokens == "Empty Name" or tokens == []:
         return "Empty Name"
 
-    if tokens[-1] in ["jr", "sr", "ii", "iii", "iv", "v"]:
+    while tokens[-1] in suffixes:
         tokens = tokens[:-1]
+        if not tokens:  # Avoids IndexError if all tokens are removed.
+            return "Empty Name"
 
     id = tokens[-1]
 

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -1093,15 +1093,8 @@ def name_selector(tokens) -> str:
     # Ex: John Smith Jr
     elif tokens[-1] in ["jr", "sr", "ii", "iii", "iv", "v"]:
         tokens = tokens[:-1]
-    # Ex: John Smith
-    elif len(tokens) == 2:
-        id = tokens[1]
-    # John George Smith
-    elif len(tokens) == 3:
-        id = tokens[2]
-    # John George Theodore Smith
-    else:
-        id = tokens[-1]
+
+    id = tokens[-1]
 
     return id
 

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -1083,7 +1083,7 @@ def split_logic(words: str):
 
     _and = re.search(
         r"\b and\b|\b an$\b|\b a$\b|f k a|\bfka\b| n k a|\bnka\b|"
-        r"\b aka\b|a k a|\b kna\b|k n a| f k$|n k$|a k$|\b not\b| married",
+        r"\b aka\b|a k a(?=\\s|$)|\b kna\b|k n a| f k$|n k$|a k$|\b not\b| married",
         words,
     )
 

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -549,7 +549,6 @@ def get_sale_counts(dups: pd.DataFrame) -> pd.DataFrame:
         dups.pin.value_counts()
         .reset_index()
         .rename(columns={"count": "sv_sale_dup_counts"})
-        # .rename(columns={"index": "pin", "pin": "sv_sale_dup_counts"})
     )
 
     dups = pd.merge(dups, v_counts)

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -1,6 +1,6 @@
 """
 This file contains all necessary functions to create a DataFrame ready to use for
-non-arms length transaction detection using statistical and heurstic methods.
+non-arms length transaction detection using statistical and heuristic methods.
 """
 
 import re

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -902,15 +902,7 @@ def get_id(row: pd.Series, col: str) -> str:
     if words.isspace() or re.search(r"^[.]*$", words):
         id = "Empty Name"
         return id
-    """
-    if pd.isnull(row[column]):
-        id = "Empty Name"
-        return id
-    
-    if words in ["none", "nan"]:
-        id = "Empty Name"
-        return id
-    """
+
     if any(x in words for x in ["vt investment corpor", "v t investment corp"]):
         return "vt investment corporation"
 
@@ -1073,7 +1065,6 @@ def split_logic(words: str):
         'Empty Name' if string is empty
         tokens (list): list of tokens in string from split
     """
-    print(f"(split_logic) words at start of function : {words}")
     words = re.sub(" +", " ", words)
 
     if words.isspace() or re.search(r"^[.]*$", words) or words == "Empty Name":
@@ -1092,7 +1083,6 @@ def split_logic(words: str):
         tokens = tokens[0].strip().split()
     else:
         tokens = words.split()
-    print(f"(split_logic) tokens at end of function : {tokens}")
 
     return tokens
 
@@ -1109,8 +1099,7 @@ def name_selector(tokens) -> str:
 
     if tokens == "Empty Name" or tokens == []:
         return "Empty Name"
-    # Ex: John Smith Jr
-    print(f"(name_selector)tokens before accessing last element: {tokens}")
+
     if tokens[-1] in ["jr", "sr", "ii", "iii", "iv", "v"]:
         tokens = tokens[:-1]
 

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -1088,13 +1088,13 @@ def name_selector(tokens) -> str:
     """
     if not tokens:
         return "Empty Name"
-    if tokens == "Empty Name":
+    elif tokens == "Empty Name":
         return tokens
     # Ex: John Smith Jr
-    if tokens[-1] in ["jr", "sr", "ii", "iii", "iv", "v"]:
+    elif tokens[-1] in ["jr", "sr", "ii", "iii", "iv", "v"]:
         tokens = tokens[:-1]
     # Ex: John Smith
-    if len(tokens) == 2:
+    elif len(tokens) == 2:
         id = tokens[1]
     # John George Smith
     elif len(tokens) == 3:

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -1236,11 +1236,6 @@ def create_name_match(row: pd.Series) -> str:
     else:
         value = "No match"
 
-    if row["sv_buyer_id"] == row["sv_seller_id"] and row["sv_buyer_id"] != "Empty Name":
-        value = row["sv_seller_id"]
-    else:
-        value = "No match"
-
     return value
 
 

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -892,6 +892,10 @@ def get_id(row: pd.Series, col: str) -> str:
         id = "Empty Name"
         return id
 
+    if pd.isnull(row[column]):
+        id = "Empty Name"
+        return id
+
     if any(x in words for x in ["vt investment corpor", "v t investment corp"]):
         return "vt investment corporation"
 
@@ -1086,13 +1090,12 @@ def name_selector(tokens) -> str:
         'Empty Name' if name is empty.
         id (str): identified last name
     """
+
     if not tokens:
         return "Empty Name"
-    elif tokens == "Empty Name":
-        return tokens
-    # Ex: John Smith Jr
     elif tokens[-1] in ["jr", "sr", "ii", "iii", "iv", "v"]:
         tokens = tokens[:-1]
+    print(f"tokens before accessing last element: {tokens}")
 
     id = tokens[-1]
 
@@ -1201,23 +1204,6 @@ def create_judicial_flag(df: pd.DataFrame) -> pd.DataFrame:
     )
 
     return df
-
-
-def create_match_flag(row: pd.Series) -> str:
-    """
-    Creates a column that says whether the buyer/seller id match.
-    Meant for apply().
-    Inputs:
-        row: from dataframe
-    Outputs:
-        value (str): whether the buyer and seller ID match
-    """
-    if row["buyer_id"] == row["seller_id"] and row["buyer_id"] != "Empty Name":
-        value = "Buyer ID and Seller ID match"
-    else:
-        value = "No match"
-
-    return value
 
 
 def create_name_match(row: pd.Series) -> str:

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -885,6 +885,11 @@ def get_id(row: pd.Series, col: str) -> str:
     column = col + "_name"
     words = str(row[column]).lower()
 
+    # Check for missing values first
+    if pd.isnull(row[column]) or words in ["none", "nan"]:
+        id = "Empty Name"
+        return id
+
     words = re.sub(r" amp ", "", words)
     words = re.sub(" +", " ", words)
 
@@ -1226,6 +1231,11 @@ def create_name_match(row: pd.Series) -> str:
     Outputs:
         value (str or None): string match if applicable, None otherwise
     """
+    if row["sv_buyer_id"] == row["sv_seller_id"] and row["sv_buyer_id"] != "Empty Name":
+        value = row["sv_seller_id"]
+    else:
+        value = "No match"
+
     if row["sv_buyer_id"] == row["sv_seller_id"] and row["sv_buyer_id"] != "Empty Name":
         value = row["sv_seller_id"]
     else:

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -886,7 +886,13 @@ def get_id(row: pd.Series, col: str) -> str:
     words = str(row[column]).lower()
 
     # Check for missing values first
-    if pd.isnull(row[column]) or words in ["none", "nan"]:
+    if pd.isnull(row[column]) or words in [
+        "none",
+        "nan",
+        "unknown",
+        "missing seller name",
+        "missing buyer name",
+    ]:
         id = "Empty Name"
         return id
 

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -1108,20 +1108,13 @@ def name_selector(tokens) -> str:
     """
 
     if tokens == "Empty Name" or tokens == []:
-        return tokens
+        return "Empty Name"
     # Ex: John Smith Jr
     print(f"(name_selector)tokens before accessing last element: {tokens}")
     if tokens[-1] in ["jr", "sr", "ii", "iii", "iv", "v"]:
         tokens = tokens[:-1]
-    # Ex: John Smith
-    if len(tokens) == 2:
-        id = tokens[1]
-    # John George Smith
-    if len(tokens) == 3:
-        id = tokens[2]
-    # John George Theodore Smith
-    else:
-        id = tokens[-1]
+
+    id = tokens[-1]
 
     return id
 

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -891,11 +891,15 @@ def get_id(row: pd.Series, col: str) -> str:
     if words.isspace() or re.search(r"^[.]*$", words):
         id = "Empty Name"
         return id
-
+    """
     if pd.isnull(row[column]):
         id = "Empty Name"
         return id
-
+    
+    if words in ["none", "nan"]:
+        id = "Empty Name"
+        return id
+    """
     if any(x in words for x in ["vt investment corpor", "v t investment corp"]):
         return "vt investment corporation"
 
@@ -1091,13 +1095,20 @@ def name_selector(tokens) -> str:
         id (str): identified last name
     """
 
-    if not tokens:
-        return "Empty Name"
-    elif tokens[-1] in ["jr", "sr", "ii", "iii", "iv", "v"]:
+    if tokens == "Empty Name":
+        return tokens
+    # Ex: John Smith Jr
+    if tokens[-1] in ["jr", "sr", "ii", "iii", "iv", "v"]:
         tokens = tokens[:-1]
-    print(f"tokens before accessing last element: {tokens}")
-
-    id = tokens[-1]
+    # Ex: John Smith
+    if len(tokens) == 2:
+        id = tokens[1]
+    # John George Smith
+    if len(tokens) == 3:
+        id = tokens[2]
+    # John George Theodore Smith
+    else:
+        id = tokens[-1]
 
     return id
 

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -1067,7 +1067,7 @@ def split_logic(words: str):
         'Empty Name' if string is empty
         tokens (list): list of tokens in string from split
     """
-
+    print(f"(split_logic) words at start of function : {words}")
     words = re.sub(" +", " ", words)
 
     if words.isspace() or re.search(r"^[.]*$", words) or words == "Empty Name":
@@ -1086,6 +1086,7 @@ def split_logic(words: str):
         tokens = tokens[0].strip().split()
     else:
         tokens = words.split()
+    print(f"(split_logic) tokens at end of function : {tokens}")
 
     return tokens
 
@@ -1103,6 +1104,7 @@ def name_selector(tokens) -> str:
     if tokens == "Empty Name":
         return tokens
     # Ex: John Smith Jr
+    print(f"(name_selector)tokens before accessing last element: {tokens}")
     if tokens[-1] in ["jr", "sr", "ii", "iii", "iv", "v"]:
         tokens = tokens[:-1]
     # Ex: John Smith

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -1107,7 +1107,7 @@ def name_selector(tokens) -> str:
         id (str): identified last name
     """
 
-    if tokens == "Empty Name":
+    if tokens == "Empty Name" or tokens == []:
         return tokens
     # Ex: John Smith Jr
     print(f"(name_selector)tokens before accessing last element: {tokens}")

--- a/manual_flagging/src/flagging_rolling.py
+++ b/manual_flagging/src/flagging_rolling.py
@@ -1052,7 +1052,7 @@ def split_logic(words: str):
         words (str): cleaned str from get_id
     Outputs:
         'Empty Name' if string is empty
-        tokens (list): lsit of tokens in string from split
+        tokens (list): list of tokens in string from split
     """
 
     words = re.sub(" +", " ", words)
@@ -1086,6 +1086,8 @@ def name_selector(tokens) -> str:
         'Empty Name' if name is empty.
         id (str): identified last name
     """
+    if not tokens:
+        return "Empty Name"
     if tokens == "Empty Name":
         return tokens
     # Ex: John Smith Jr
@@ -1095,7 +1097,7 @@ def name_selector(tokens) -> str:
     if len(tokens) == 2:
         id = tokens[1]
     # John George Smith
-    if len(tokens) == 3:
+    elif len(tokens) == 3:
         id = tokens[2]
     # John George Theodore Smith
     else:
@@ -1164,7 +1166,7 @@ def clean_id(row: pd.Series, col: str) -> str:
     """
     Cleans id field after get_role() by removing role.
     Inputs:
-        row: from padnas dataframe
+        row: from pandas dataframe
         col (str): column to process. 'seller' or 'buyer'
     Outputs:
         words (str): seller/buyer id without role.

--- a/manual_flagging/yaml/inputs_initial.yaml
+++ b/manual_flagging/yaml/inputs_initial.yaml
@@ -22,7 +22,7 @@ dev_bounds: [2, 3]
 # sale.flag table. Leave 'end' blank if we want to flag all sales
 # since the start date
 time_frame:
-  start: "2019-01-01"
+  start: "2014-01-01"
   end: "2020-06-30"
 
 # How many total months to include in the grouping methodology


### PR DESCRIPTION
The code now runs with the entire 2014- sales query.  I believe the reason that it was not running was because `name_selector()` didn't handle the case where `split_logic()` looked at NA values in buyer or seller name.

`name_selector()` takes the return value of `split_logic()` as an argument in `clean_id()`. Specifically this happens in these two lines:

``` 
df["sv_buyer_id"] = df.apply(clean_id, args=("sv_buyer",), axis=1)
df["sv_seller_id"] = df.apply(clean_id, args=("sv_seller",), axis=1)
```
The fix here essentially converts the NA values to an "Empty Name" string value.

Before, there was an out of index error, since the NA value was being indexed.

Closes #29 