### PR TITLE
Remove flag table integration from recurring script

### DIFF
--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -875,12 +875,22 @@ if __name__ == "__main__":
             start_date=args["time_frame_start"],
             manual_update=False,
         )
-
+        """
         # Filter to keep only flags not already present in the flag table
         rows_to_append = df_flagged_final[
             ~df_flagged_final["meta_sale_document_num"].isin(
                 df_sales_val["meta_sale_document_num"]
             )
+        ].reset_index(drop=True)
+        """
+        # Find rows in df_ingest_full with sv_is_outlier having a value
+        existing_flags = df_ingest_full.dropna(subset=["sv_is_outlier"])[
+            "meta_sale_document_num"
+        ]
+
+        # Filter out rows from df_flagged_final that are in the above subset
+        rows_to_append = df_flagged_final[
+            ~df_flagged_final["meta_sale_document_num"].isin(existing_flags)
         ].reset_index(drop=True)
 
         # Write to sale.flag table

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -721,7 +721,7 @@ if __name__ == "__main__":
         INNER JOIN default.vw_pin_sale sale
             ON sale.pin = data.pin
             AND sale.year = data.year
-        LEFT JOIN {args["sale_flag_table"]} flag
+        INNER JOIN {args["sale_flag_table"]} flag
             ON flag.meta_sale_document_num = sale.doc_no
         WHERE flag.sv_is_outlier IS NULL
         AND sale.sale_date >= DATE '{args["time_frame_start"]}'

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -718,7 +718,7 @@ if __name__ == "__main__":
             MIN(DATE_TRUNC('MONTH', sale.sale_date)) - INTERVAL '{rolling_window_num_sql}' MONTH AS StartDate,
             MAX(DATE_TRUNC('MONTH', sale.sale_date)) AS EndDate
         FROM CombinedData data
-        INNER JOIN default.vw_pin_sale sale
+        INNER JOIN "ci_model_sales_val_53_update_recurring_scripts_to_use_updated_view_1_sale.dev_sales_val_vw_pin_sale sale
             ON sale.pin = data.pin
             AND sale.year = data.year
         WHERE sale.sv_is_outlier IS NULL
@@ -745,7 +745,7 @@ if __name__ == "__main__":
         sale.sv_is_heuristic_outlier,
         sale.sv_outlier_type
     FROM CombinedData data
-    INNER JOIN default.vw_pin_sale sale
+    INNER JOIN "ci_model_sales_val_53_update_recurring_scripts_to_use_updated_view_1_sale.dev_sales_val_vw_pin_sale sale
         ON sale.pin = data.pin
         AND sale.year = data.year
     INNER JOIN NA_Dates

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -721,7 +721,7 @@ if __name__ == "__main__":
         INNER JOIN default.vw_pin_sale sale
             ON sale.pin = data.pin
             AND sale.year = data.year
-        INNER JOIN {args["sale_flag_table"]} flag
+        LEFT JOIN {args["sale_flag_table"]} flag
             ON flag.meta_sale_document_num = sale.doc_no
         WHERE flag.sv_is_outlier IS NULL
         AND sale.sale_date >= DATE '{args["time_frame_start"]}'

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -718,7 +718,7 @@ if __name__ == "__main__":
             MIN(DATE_TRUNC('MONTH', sale.sale_date)) - INTERVAL '{rolling_window_num_sql}' MONTH AS StartDate,
             MAX(DATE_TRUNC('MONTH', sale.sale_date)) AS EndDate
         FROM CombinedData data
-        INNER JOIN ci_model_sales_val_53_update_recurring_scripts_to_use_updated_view_1_sale.dev_sales_val_vw_pin_sale sale
+        INNER JOIN default.vw_pin_sale sale
             ON sale.pin = data.pin
             AND sale.year = data.year
         WHERE sale.sv_is_outlier IS NULL
@@ -745,7 +745,7 @@ if __name__ == "__main__":
         sale.sv_is_heuristic_outlier,
         sale.sv_outlier_type
     FROM CombinedData data
-    INNER JOIN ci_model_sales_val_53_update_recurring_scripts_to_use_updated_view_1_sale.dev_sales_val_vw_pin_sale sale
+    INNER JOIN default.vw_pin_sale sale
         ON sale.pin = data.pin
         AND sale.year = data.year
     INNER JOIN NA_Dates

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -781,11 +781,14 @@ if __name__ == "__main__":
     df_ingest_full = as_pandas(cursor)
     df = df_ingest_full
 
+    print(df)
+
     # Filter the dataframe to look at sales we are interested in flagging,
     # not prior rolling window data
     filtered_df = df_ingest_full[
         df_ingest_full["meta_sale_date"] >= args["time_frame_start"]
     ]
+    print(filtered_df)
 
     # Skip rest of script if no new unflagged sales
     if filtered_df.sv_outlier_type.isna().sum() == 0:

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -718,7 +718,7 @@ if __name__ == "__main__":
             MIN(DATE_TRUNC('MONTH', sale.sale_date)) - INTERVAL '{rolling_window_num_sql}' MONTH AS StartDate,
             MAX(DATE_TRUNC('MONTH', sale.sale_date)) AS EndDate
         FROM CombinedData data
-        INNER JOIN "ci_model_sales_val_53_update_recurring_scripts_to_use_updated_view_1_sale.dev_sales_val_vw_pin_sale sale
+        INNER JOIN ci_model_sales_val_53_update_recurring_scripts_to_use_updated_view_1_sale.dev_sales_val_vw_pin_sale sale
             ON sale.pin = data.pin
             AND sale.year = data.year
         WHERE sale.sv_is_outlier IS NULL
@@ -745,7 +745,7 @@ if __name__ == "__main__":
         sale.sv_is_heuristic_outlier,
         sale.sv_outlier_type
     FROM CombinedData data
-    INNER JOIN "ci_model_sales_val_53_update_recurring_scripts_to_use_updated_view_1_sale.dev_sales_val_vw_pin_sale sale
+    INNER JOIN ci_model_sales_val_53_update_recurring_scripts_to_use_updated_view_1_sale.dev_sales_val_vw_pin_sale sale
         ON sale.pin = data.pin
         AND sale.year = data.year
     INNER JOIN NA_Dates

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -739,7 +739,7 @@ if __name__ == "__main__":
         data.pin,
         data.char_bldg_sf,
         data.indicator, -- Selecting the indicator column
-        sale.run_id,
+        sale.sv_run_id,
         sale.sv_is_outlier,
         sale.sv_is_ptax_outlier,
         sale.sv_is_heuristic_outlier,

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -721,9 +721,7 @@ if __name__ == "__main__":
         INNER JOIN default.vw_pin_sale sale
             ON sale.pin = data.pin
             AND sale.year = data.year
-        LEFT JOIN {args["sale_flag_table"]} flag
-            ON flag.meta_sale_document_num = sale.doc_no
-        WHERE flag.sv_is_outlier IS NULL
+        WHERE sale.sv_is_outlier IS NULL
         AND sale.sale_date >= DATE '{args["time_frame_start"]}'
         AND NOT sale.is_multisale
         AND (NOT data.pin_is_multicard OR data.source_table = 'condo_char')
@@ -741,17 +739,15 @@ if __name__ == "__main__":
         data.pin,
         data.char_bldg_sf,
         data.indicator, -- Selecting the indicator column
-        flag.run_id,
-        flag.sv_is_outlier,
-        flag.sv_is_ptax_outlier,
-        flag.sv_is_heuristic_outlier,
-        flag.sv_outlier_type
+        sale.run_id,
+        sale.sv_is_outlier,
+        sale.sv_is_ptax_outlier,
+        sale.sv_is_heuristic_outlier,
+        sale.sv_outlier_type
     FROM CombinedData data
     INNER JOIN default.vw_pin_sale sale
         ON sale.pin = data.pin
         AND sale.year = data.year
-    LEFT JOIN {args["sale_flag_table"]} flag
-        ON flag.meta_sale_document_num = sale.doc_no
     INNER JOIN NA_Dates
         ON sale.sale_date BETWEEN NA_Dates.StartDate AND NA_Dates.EndDate
     WHERE NOT sale.is_multisale

--- a/main.tf
+++ b/main.tf
@@ -154,7 +154,7 @@ resource "aws_glue_job" "sales_val_flagging" {
     "--stat_groups"               = "rolling_window,township_code,class"
     "--iso_forest"                = "meta_sale_price,sv_price_per_sqft,sv_days_since_last_transaction,sv_cgdr,sv_sale_dup_counts"
     "--rolling_window_num"        = 12
-    "--time_frame_start"          = "2023-01-01"
+    "--time_frame_start"          = "2014-01-01"
     "--dev_bounds"                = "2,3"
     "--additional-python-modules" = "boto3==1.28.12,pandas==2.0.2"
     "--commit_sha"                = var.commit_sha

--- a/main.tf
+++ b/main.tf
@@ -154,7 +154,7 @@ resource "aws_glue_job" "sales_val_flagging" {
     "--stat_groups"               = "rolling_window,township_code,class"
     "--iso_forest"                = "meta_sale_price,sv_price_per_sqft,sv_days_since_last_transaction,sv_cgdr,sv_sale_dup_counts"
     "--rolling_window_num"        = 12
-    "--time_frame_start"          = "2014-01-01"
+    "--time_frame_start"          = "2023-01-01"
     "--dev_bounds"                = "2,3"
     "--additional-python-modules" = "boto3==1.28.12,pandas==2.0.2"
     "--commit_sha"                = var.commit_sha


### PR DESCRIPTION
I tested this with a date floor of `2023-01-01`. It successfully writes the data, and then when we run it again afterwards, it prints `"WARNING: No new sales to flag"` from line 783. Final step is for me to run the production data and inspect the results after merging.
