### PR TITLE
#19 Improve Sale Validation Heuristics - Modifications for Lawyer and Delaware

### DIFF
--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -916,7 +916,7 @@ entity_keywords = (
     r"|apostolic church|lutheran church|catholic church|\bfed\b|nationstar"
     r"|advantage|commercial|health|condominium|nationa|association|homeowner"
     r"|christ church|christian church|baptist church|community church"
-    r"|church of c"
+    r"|church of c|lawyer|delaw"
 )
 
 

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -916,7 +916,7 @@ entity_keywords = (
     r"|apostolic church|lutheran church|catholic church|\bfed\b|nationstar"
     r"|advantage|commercial|health|condominium|nationa|association|homeowner"
     r"|christ church|christian church|baptist church|community church"
-    r"|church of c|lawyer|delaw"
+    r"|church of c|lawyer|delawar"
 )
 
 


### PR DESCRIPTION
When law was redefined to require a full word match, instances of lawyer and Delaware were missed. 

The e is intentionally left off because the word is sometimes truncated.

There are also instances where it Delaware coded as "delaw", but this overlaps with names like Delawrence.