### PR TITLE
Modified string matching for `lawyer` and `delaware`

### DIFF
--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -916,7 +916,7 @@ entity_keywords = (
     r"|apostolic church|lutheran church|catholic church|\bfed\b|nationstar"
     r"|advantage|commercial|health|condominium|nationa|association|homeowner"
     r"|christ church|christian church|baptist church|community church"
-    r"|church of c"
+    r"|church of c|\bdelaw\b|lawyer|delawar"
 )
 
 


### PR DESCRIPTION
The switch from law to /blaw/b got rid of many erroneous flags, but also removed accurate flags. These mostly related to the words lawyer and Delaware.

Delaware is often truncated, so shortened versions of the word are used to optimize the matching.