### PR TITLE
Switch Glue job type to Spark instead of Python shell

### DIFF
--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -543,15 +543,16 @@ def get_sale_counts(dups: pd.DataFrame) -> pd.DataFrame:
     Calculates how many times transactions occured for a gieven property.
     Helper for dup_stats()
     Inputs:
-        df (pd.DataFrame): pandsa dataframe4
+        df (pd.DataFrame): pandas dataframe
     """
     v_counts = (
         dups.pin.value_counts()
         .reset_index()
-        .rename(columns={"count": "sv_sale_dup_counts"})
+        .rename(columns={"index": "pin", "pin": "sv_sale_dup_counts"})
     )
 
-    dups = pd.merge(dups, v_counts)
+    # Explicitly specify the merging columns
+    dups = pd.merge(dups, v_counts, on="pin")
 
     return dups
 

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -786,7 +786,11 @@ if __name__ == "__main__":
     if filtered_df.sv_outlier_type.isna().sum() == 0:
         print("WARNING: No new sales to flag")
     else:
+        print(df)
+        print(df.dtypes)
+        print(metadata)
         df = df.astype({col[0]: sql_type_to_pd_type(col[1]) for col in metadata})
+        print(df.dtypes)
         df["ptax_flag_original"].fillna(False, inplace=True)
 
         # Separate res and condo sales based on the indicator column

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -786,9 +786,7 @@ if __name__ == "__main__":
     if filtered_df.sv_outlier_type.isna().sum() == 0:
         print("WARNING: No new sales to flag")
     else:
-        print(df)
-        print(df.dtypes)
-        print(metadata)
+        # Make sure None types aren't utilized in type conversion
         conversion_dict = {
             col[0]: sql_type_to_pd_type(col[1])
             for col in metadata
@@ -796,7 +794,6 @@ if __name__ == "__main__":
         }
         df = df.astype(conversion_dict)
 
-        print(df.dtypes)
         df["ptax_flag_original"].fillna(False, inplace=True)
 
         # Separate res and condo sales based on the indicator column

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -789,7 +789,13 @@ if __name__ == "__main__":
         print(df)
         print(df.dtypes)
         print(metadata)
-        df = df.astype({col[0]: sql_type_to_pd_type(col[1]) for col in metadata})
+        conversion_dict = {
+            col[0]: sql_type_to_pd_type(col[1])
+            for col in metadata
+            if sql_type_to_pd_type(col[1]) is not None
+        }
+        df = df.astype(conversion_dict)
+
         print(df.dtypes)
         df["ptax_flag_original"].fillna(False, inplace=True)
 

--- a/main.tf
+++ b/main.tf
@@ -132,12 +132,12 @@ resource "aws_glue_job" "sales_val_flagging" {
   name            = local.glue_job_name
   role_arn        = var.iam_role_arn
   max_retries     = 0
-  max_capacity    = "1.0"
   glue_version    = "3.0"
   execution_class = "STANDARD"
+  worker_type     = "G.4X"
 
   command {
-    name            = "pythonshell"
+    name            = "glueetl"
     script_location = "s3://${aws_s3_object.sales_val_flagging.bucket}/${aws_s3_object.sales_val_flagging.key}"
     python_version  = "3.9"
   }

--- a/main.tf
+++ b/main.tf
@@ -134,8 +134,8 @@ resource "aws_glue_job" "sales_val_flagging" {
   max_retries       = 0
   glue_version      = "3.0"
   execution_class   = "STANDARD"
-  worker_type       = "G.4X"
-  number_of_workers = 1
+  worker_type       = "G.2X"
+  number_of_workers = 2
 
   command {
     name            = "glueetl"

--- a/main.tf
+++ b/main.tf
@@ -154,9 +154,9 @@ resource "aws_glue_job" "sales_val_flagging" {
     "--stat_groups"               = "rolling_window,township_code,class"
     "--iso_forest"                = "meta_sale_price,sv_price_per_sqft,sv_days_since_last_transaction,sv_cgdr,sv_sale_dup_counts"
     "--rolling_window_num"        = 12
-    "--time_frame_start"          = "2014-01-01"
+    "--time_frame_start"          = "2023-01-01"
     "--dev_bounds"                = "2,3"
-    "--additional-python-modules" = "boto3==1.28.12,pandas==2.0.2"
+    "--additional-python-modules" = "boto3==1.28.12,pandas==1.3.5,awswrangler==2.20.1,pyathena==2.25.2"
     "--commit_sha"                = var.commit_sha
     "--min_groups_threshold"      = "30"
     "--ptax_sd"                   = "1,1"

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,6 @@ resource "aws_glue_job" "sales_val_flagging" {
   command {
     name            = "glueetl"
     script_location = "s3://${aws_s3_object.sales_val_flagging.bucket}/${aws_s3_object.sales_val_flagging.key}"
-    python_version  = "3.9"
   }
 
   default_arguments = {

--- a/main.tf
+++ b/main.tf
@@ -154,7 +154,7 @@ resource "aws_glue_job" "sales_val_flagging" {
     "--stat_groups"               = "rolling_window,township_code,class"
     "--iso_forest"                = "meta_sale_price,sv_price_per_sqft,sv_days_since_last_transaction,sv_cgdr,sv_sale_dup_counts"
     "--rolling_window_num"        = 12
-    "--time_frame_start"          = "2023-01-01"
+    "--time_frame_start"          = "2014-01-01"
     "--dev_bounds"                = "2,3"
     "--additional-python-modules" = "boto3==1.28.12,pandas==1.3.5,awswrangler==2.20.1,pyathena==2.25.2"
     "--commit_sha"                = var.commit_sha

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ variable "commit_sha" {
 
 resource "aws_s3_bucket" "glue_assets" {
   # Prod buckets are managed outside this config
-  count         = terraform.workspace == "prod" ? 0 : 1
+  count = terraform.workspace == "prod" ? 0 : 1
   # Buckets can only be a max of 63 characters long:
   # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
   bucket        = "ccao-ci-${substr(terraform.workspace, 0, 33)}-glue-assets-us-east-1"
@@ -129,12 +129,13 @@ resource "aws_s3_object" "flagging_script" {
 }
 
 resource "aws_glue_job" "sales_val_flagging" {
-  name            = local.glue_job_name
-  role_arn        = var.iam_role_arn
-  max_retries     = 0
-  glue_version    = "3.0"
-  execution_class = "STANDARD"
-  worker_type     = "G.4X"
+  name              = local.glue_job_name
+  role_arn          = var.iam_role_arn
+  max_retries       = 0
+  glue_version      = "3.0"
+  execution_class   = "STANDARD"
+  worker_type       = "G.4X"
+  number_of_workers = 1
 
   command {
     name            = "glueetl"

--- a/manual_flagging/initial_flagging.py
+++ b/manual_flagging/initial_flagging.py
@@ -110,7 +110,12 @@ metadata = cursor.description
 df_ingest = as_pandas(cursor)
 df = df_ingest
 
-df = df.astype({col[0]: flg.sql_type_to_pd_type(col[1]) for col in metadata})
+conversion_dict = {
+    col[0]: flg.sql_type_to_pd_type(col[1])
+    for col in metadata
+    if flg.sql_type_to_pd_type(col[1]) is not None
+}
+df = df.astype(conversion_dict)
 df["ptax_flag_original"].fillna(False, inplace=True)
 
 # Separate res and condo sales based on the indicator column

--- a/manual_flagging/manual_update.py
+++ b/manual_flagging/manual_update.py
@@ -121,7 +121,12 @@ cursor.execute(SQL_QUERY_SALES_VAL)
 df_ingest_flag = as_pandas(cursor)
 df_flag_table = df_ingest_flag
 
-df = df.astype({col[0]: flg.sql_type_to_pd_type(col[1]) for col in metadata})
+conversion_dict = {
+    col[0]: flg.sql_type_to_pd_type(col[1])
+    for col in metadata
+    if flg.sql_type_to_pd_type(col[1]) is not None
+}
+df = df.astype(conversion_dict)
 df["ptax_flag_original"].fillna(False, inplace=True)
 
 # Separate res and condo sales based on the indicator column

--- a/manual_flagging/requirements.txt
+++ b/manual_flagging/requirements.txt
@@ -1,4 +1,4 @@
-awswrangler==3.3.0
+awswrangler==2.20.1
 boto3==1.28.26
 botocore==1.31.26
 certifi==2023.7.22
@@ -9,12 +9,12 @@ idna==3.4
 iniconfig==2.0.0
 jmespath==1.0.1
 joblib==1.3.2
-numpy==1.24.3
+numpy==1.23.4
 packaging==23.1
-pandas==2.0.2
+pandas==1.3.5
 pluggy==1.2.0
-pyarrow==12.0.1
-pyathena==3.0.6
+pyarrow==10.0.0
+pyathena==2.25.2
 pytest==7.4.0
 python-dateutil==2.8.2
 pytz==2022.1


### PR DESCRIPTION
This PR is primarily authored by @wagnerlmichael. [Michael's description below](https://github.com/ccao-data/model-sales-val/pull/64#issuecomment-1781375188):

> This PR adjusts the glue script to a spark job in order to take advantage of more compute resources. In the old python shell job, we would get an out of memory error if the ingest took in too much data.
>
> I've tested both glue and local - both run without issue and the proportion of flags are almost exactly the same. The work involved mostly troubleshooting package changes since the new spark glue job does not support some of the package versions we had been using. I standardized the package changes in local and in glue.