### PR TITLE
Add log10 price transformation before outlier detection

### DIFF
--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -696,7 +696,8 @@ def z_normalize(df: pd.DataFrame, columns: list) -> pd.DataFrame:
                            as 'column_name_zscore'
     """
     for col in columns:
-        df["sv_" + col + "_deviation_county"] = zscore(df[col], nan_policy="omit")
+        log_values = np.log(df[col])
+        df["sv_" + col + "_deviation_county"] = zscore(log_values, nan_policy="omit")
 
     return df
 

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -185,10 +185,10 @@ def pricing_info(
     """
     group_string = create_group_string(groups, "_")
 
-    columns_to_normalize = ["meta_sale_price"]
+    columns_to_log = ["meta_sale_price"]
     if not condos:
-        columns_to_normalize.append("sv_price_per_sqft")
-    df = z_normalize(df, columns_to_normalize)
+        columns_to_log.append("sv_price_per_sqft")
+    df = log_transform(df, columns_to_log)
 
     prices = [
         f"sv_price_deviation_{group_string}",
@@ -684,20 +684,18 @@ def get_thresh(df: pd.DataFrame, cols: list, permut: tuple, groups: tuple) -> di
     return stds
 
 
-def z_normalize(df: pd.DataFrame, columns: list) -> pd.DataFrame:
+def log_transform(df: pd.DataFrame, columns: list) -> pd.DataFrame:
     """
-    Do zscore normalization on given column set so that
-    we can compare them apples to apples.
+    Apply log transformation on given column set.
     Inputs:
         df (pd.DataFrame):
-        columns (list): columns to be normalized
+        columns (list): columns to be transformed
     Outputs:
-        df (pd.DataFrame): dataframe with given columns normalized
-                           as 'column_name_zscore'
+        df (pd.DataFrame): dataframe with given columns replaced
+                           by their logged values
     """
     for col in columns:
-        log_values = np.log(df[col])
-        df["sv_" + col + "_deviation_county"] = zscore(log_values, nan_policy="omit")
+        df[col] = np.log(df[col])
 
     return df
 

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -690,7 +690,7 @@ def z_normalize(df: pd.DataFrame, columns: list) -> pd.DataFrame:
     we can compare them apples to apples.
     Inputs:
         df (pd.DataFrame):
-        columns (list): columsn to be normalized
+        columns (list): columns to be normalized
     Outputs:
         df (pd.DataFrame): dataframe with given columns normalized
                            as 'column_name_zscore'
@@ -704,14 +704,14 @@ def z_normalize(df: pd.DataFrame, columns: list) -> pd.DataFrame:
 
 def z_normalize_groupby(s: pd.Series):
     """
-    Function used to z_normailize groups of records.
-    Pandas stiches it back together into a complete column.
+    Function used to z_normalize groups of records.
+    Pandas stitches it back together into a complete column.
     Meant for groupby.apply().
     Inputs:
         s(pd.Series): grouped series from groupby.apply
-    Ouputs:
+    Outputs:
         z_normalized series grouped by class and township
-        that is then stiched into complete column by pandas
+        that is then stitched into complete column by pandas
     """
     log_values = np.log(s)  # Take the log of the series values before normalization
     return zscore(log_values, nan_policy="omit")

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -713,7 +713,8 @@ def z_normalize_groupby(s: pd.Series):
         z_normalized series grouped by class and township
         that is then stiched into complete column by pandas
     """
-    return zscore(s, nan_policy="omit")
+    log_values = np.log(s)  # Take the log of the series values before normalization
+    return zscore(log_values, nan_policy="omit")
 
 
 def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -711,8 +711,8 @@ def z_normalize_groupby(s: pd.Series):
         z_normalized series grouped by class and township
         that is then stitched into complete column by pandas
     """
-    log_values = np.log(s)  # Take the log of the series values before normalization
-    return zscore(log_values, nan_policy="omit")
+
+    return zscore(s, nan_policy="omit")
 
 
 def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -695,7 +695,7 @@ def log_transform(df: pd.DataFrame, columns: list) -> pd.DataFrame:
                            by their logged values
     """
     for col in columns:
-        df[col] = np.log(df[col])
+        df[col] = np.log10(df[col])
 
     return df
 


### PR DESCRIPTION
Fix the methodology to include log 10 transformation before z normalization for flagging. More details in #65.

Closes #65 