### PR TITLE
Change params table to utilize athena arrays

### DIFF
--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -499,10 +499,6 @@ def modify_dtypes(df):
         df: df of standardized dtypes
     """
 
-    # Convert object columns to string
-    for col in df.select_dtypes("object").columns:
-        df[col] = df[col].astype("string")
-
     # Convert Int64 columns to int64
     for col in df.select_dtypes("Int64").columns:
         df[col] = df[col].astype("int64")


### PR DESCRIPTION
Edited `modify_dtypes` in order to fix the athena dtype overwrite. The `sale.parameter` table now contains the correct dtypes. 

Closes #70 