### PR TITLE
Fix condo ptax flags, fix recent month ingest in glue script, add ptax directional flag

### DIFF
--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -102,7 +102,7 @@ def ptax_adjustment(df, groups, ptax_sd, condos: bool):
 
     group_string = "_".join(groups)
 
-    if condos == False:
+    if not condos:
         df["ptax_flag_w_deviation"] = df["ptax_flag_original"] & (
             (df[f"sv_price_deviation_{group_string}"] >= ptax_sd[1])
             | (df[f"sv_price_deviation_{group_string}"] <= -ptax_sd[0])

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -727,7 +727,7 @@ if __name__ == "__main__":
     NA_Dates AS (
         SELECT
             MIN(DATE_TRUNC('MONTH', sale.sale_date)) - INTERVAL '{rolling_window_num_sql}' MONTH AS StartDate,
-            MAX(DATE_TRUNC('MONTH', sale.sale_date) + INTERVAL '1 MONTH' - INTERVAL '1 DAY') AS EndDate
+            MAX(date_add('day', -1, date_add('month', 1, DATE_TRUNC('MONTH', sale.sale_date)))) AS EndDate
         FROM CombinedData data
         INNER JOIN default.vw_pin_sale sale
             ON sale.pin = data.pin

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -227,10 +227,13 @@ def finish_flags(df, start_date, manual_update):
             sv_is_outlier=lambda df: df["sv_is_autoval_outlier"]
             | df["ptax_flag_w_deviation"],
             # Incorporate PTAX in sv_outlier_type
-            sv_outlier_type=lambda df: np.where(
-                df["ptax_flag_w_deviation"],
-                "PTAX-203 flag",
-                df["sv_outlier_type"],
+            sv_outlier_type=lambda df: np.select(
+                [
+                    (df["ptax_flag_w_deviation"]) & (df["ptax_direction"] == "High"),
+                    (df["ptax_flag_w_deviation"]) & (df["ptax_direction"] == "Low"),
+                ],
+                ["PTAX-203 flag (High)", "PTAX-203 flag (Low)"],
+                default=df["sv_outlier_type"],
             ),
         )
         .assign(

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -727,7 +727,7 @@ if __name__ == "__main__":
     NA_Dates AS (
         SELECT
             MIN(DATE_TRUNC('MONTH', sale.sale_date)) - INTERVAL '{rolling_window_num_sql}' MONTH AS StartDate,
-            MAX(DATE_TRUNC('MONTH', sale.sale_date)) AS EndDate
+            MAX(DATE_TRUNC('MONTH', sale.sale_date) + INTERVAL '1 MONTH' - INTERVAL '1 DAY') AS EndDate
         FROM CombinedData data
         INNER JOIN default.vw_pin_sale sale
             ON sale.pin = data.pin

--- a/main.tf
+++ b/main.tf
@@ -154,7 +154,7 @@ resource "aws_glue_job" "sales_val_flagging" {
     "--stat_groups"               = "rolling_window,township_code,class"
     "--iso_forest"                = "meta_sale_price,sv_price_per_sqft,sv_days_since_last_transaction,sv_cgdr,sv_sale_dup_counts"
     "--rolling_window_num"        = 12
-    "--time_frame_start"          = "2014-01-01"
+    "--time_frame_start"          = "2023-01-01"
     "--dev_bounds"                = "2,2"
     "--additional-python-modules" = "boto3==1.28.12,pandas==1.3.5,awswrangler==2.20.1,pyathena==2.25.2"
     "--commit_sha"                = var.commit_sha

--- a/manual_flagging/initial_flagging.py
+++ b/manual_flagging/initial_flagging.py
@@ -175,18 +175,29 @@ df_condo_flagged_updated = flg.group_size_adjustment(
     condos=True,
 )
 
-df_flagged_merged = pd.concat(
-    [df_res_flagged_updated, df_condo_flagged_updated]
-).reset_index(drop=True)
-
-# Update the PTAX flag column with an additional std dev conditional
-df_flagged_ptax = flg.ptax_adjustment(
-    df=df_flagged_merged, groups=inputs["stat_groups"], ptax_sd=inputs["ptax_sd"]
+# Update the PTAX flag column with an additional std dev conditional w/ res groups
+df_res_flagged_updated_ptax = flg.ptax_adjustment(
+    df=df_res_flagged_updated,
+    groups=inputs["stat_groups"],
+    ptax_sd=inputs["ptax_sd"],
+    condos=False,
 )
+
+# Update the PTAX flag column with an additional std dev conditional w/ condo groups
+df_condo_flagged_updated_ptax = flg.ptax_adjustment(
+    df=df_condo_flagged_updated,
+    groups=condo_stat_groups,
+    ptax_sd=inputs["ptax_sd"],
+    condos=True,
+)
+
+df_flagged_ptax_merged = pd.concat(
+    [df_res_flagged_updated_ptax, df_condo_flagged_updated_ptax]
+).reset_index(drop=True)
 
 # Finish flagging and subset to write to flag table
 df_to_write, run_id, timestamp = flg.finish_flags(
-    df=df_flagged_ptax,
+    df=df_flagged_ptax_merged,
     start_date=inputs["time_frame"]["start"],
     manual_update=False,
 )

--- a/manual_flagging/manual_update.py
+++ b/manual_flagging/manual_update.py
@@ -210,7 +210,7 @@ df_flagged_ptax_merged = pd.concat(
 df_flagged_final, run_id, timestamp = flg.finish_flags(
     df=df_flagged_ptax_merged,
     start_date=inputs["time_frame"]["start"],
-    manual_update=False,
+    manual_update=True,
 )
 
 # -----------------------------------------------------------------------------

--- a/manual_flagging/manual_update.py
+++ b/manual_flagging/manual_update.py
@@ -186,22 +186,32 @@ df_condo_flagged_updated = flg.group_size_adjustment(
     condos=True,
 )
 
-df_flagged_merged = pd.concat(
-    [df_res_flagged_updated, df_condo_flagged_updated]
-).reset_index(drop=True)
-
-# Update the PTAX flag column with an additional std dev conditional
-df_flagged_ptax = flg.ptax_adjustment(
-    df=df_flagged_merged, groups=inputs["stat_groups"], ptax_sd=inputs["ptax_sd"]
+# Update the PTAX flag column with an additional std dev conditional w/ res groups
+df_res_flagged_updated_ptax = flg.ptax_adjustment(
+    df=df_res_flagged_updated,
+    groups=inputs["stat_groups"],
+    ptax_sd=inputs["ptax_sd"],
+    condos=False,
 )
+
+# Update the PTAX flag column with an additional std dev conditional w/ condo groups
+df_condo_flagged_updated_ptax = flg.ptax_adjustment(
+    df=df_condo_flagged_updated,
+    groups=condo_stat_groups,
+    ptax_sd=inputs["ptax_sd"],
+    condos=True,
+)
+
+df_flagged_ptax_merged = pd.concat(
+    [df_res_flagged_updated_ptax, df_condo_flagged_updated_ptax]
+).reset_index(drop=True)
 
 # Finish flagging and subset to write to flag table
 df_flagged_final, run_id, timestamp = flg.finish_flags(
-    df=df_flagged_ptax,
+    df=df_flagged_ptax_merged,
     start_date=inputs["time_frame"]["start"],
-    manual_update=True,
+    manual_update=False,
 )
-
 
 # -----------------------------------------------------------------------------
 # Update version of re-flagged sales


### PR DESCRIPTION
This PR does three things

- Adds directional flag to `sv_outlier_type` for ptax indicator
- Fixes a problem where the sales in the most recent month were getting clipped to the first day of that month in the ingest
- Makes sure condo sales get ptax flags

These changes have been tested on dev glue job resources.

Closes #86 