### PR TITLE
Update condos flags based on new res grouping method

### DIFF
--- a/manual_flagging/manual_update.py
+++ b/manual_flagging/manual_update.py
@@ -163,31 +163,25 @@ df_condo = pd.merge(df_condo, df_new_groups, on="nbhd", how="left")
 df_condo_to_flag = flg.add_rolling_window(
     df_condo, num_months=inputs["rolling_window_months"]
 )
-# Flag condo outliers, here we remove price per sqft as an input
-# for the isolation forest model since condos don't have a unit sqft
-condo_iso_forest = inputs["iso_forest"].copy()
-condo_iso_forest.remove("sv_price_per_sqft")
-
-condo_stat_groups = ["rolling_window", "geography_split"]
 
 df_condo_flagged = flg_model.go(
     df=df_condo_to_flag,
-    groups=tuple(condo_stat_groups),
-    iso_forest_cols=condo_iso_forest,
+    groups=tuple(inputs["stat_groups"]["condos"]),
+    iso_forest_cols=inputs["iso_forest"],
     dev_bounds=tuple(inputs["dev_bounds"]),
     condos=True,
 )
 
 df_condo_flagged_updated = flg.group_size_adjustment(
     df=df_condo_flagged,
-    stat_groups=condo_stat_groups,
+    stat_groups=inputs["stat_groups"]["condos"],
     min_threshold=inputs["min_groups_threshold"],
     condos=True,
 )
 
 df_condo_flagged_ptax = flg.ptax_adjustment(
     df=df_condo_flagged_updated,
-    groups=condo_stat_groups,
+    groups=inputs["stat_groups"]["condos"],
     ptax_sd=inputs["ptax_sd"],
     condos=True,
 )

--- a/manual_flagging/manual_update.py
+++ b/manual_flagging/manual_update.py
@@ -146,7 +146,7 @@ df["ptax_flag_original"].fillna(False, inplace=True)
 
 # Ingest groups
 df_new_groups = pd.read_excel(
-    os.path.join(root, "QC_salesval_nbhds_condos.xlsx"),
+    os.path.join(root, "QC_salesval_nbhds_round2.xlsx"),
     usecols=["Town Nbhd", "Town Grp 1"],
 ).rename(columns={"Town Nbhd": "nbhd", "Town Grp 1": "geography_split"})
 

--- a/manual_flagging/manual_update.py
+++ b/manual_flagging/manual_update.py
@@ -15,6 +15,9 @@ from pyathena.pandas.util import as_pandas
 root = sp.getoutput("git rev-parse --show-toplevel")
 os.chdir(os.path.join(root, "manual_flagging"))
 
+# Set time for run_id
+chicago_tz = pytz.timezone("America/Chicago")
+
 # Use yaml as inputs
 with open(os.path.join("yaml", "inputs_update.yaml"), "r") as stream:
     inputs = yaml.safe_load(stream)

--- a/manual_flagging/manual_update.py
+++ b/manual_flagging/manual_update.py
@@ -154,7 +154,6 @@ df_new_groups = pd.read_excel(
 df = df[df["triad_code"] == "1"]
 # Grab only condo data
 df_condo = df[df["indicator"] == "condo"].reset_index(drop=True)
-df_condo["nbhd"] = df_condo["nbhd"].replace("77-13", "770130")
 
 df_condo["nbhd"] = df_condo["nbhd"].astype(int)
 df_condo = pd.merge(df_condo, df_new_groups, on="nbhd", how="left")

--- a/manual_flagging/manual_update.py
+++ b/manual_flagging/manual_update.py
@@ -231,8 +231,8 @@ df_parameters = flg.get_parameter_df(
     df_to_write=df_to_write,
     df_ingest=df_ingest,
     iso_forest_cols=inputs["iso_forest"],
-    res_stat_groups=inputs["stat_groups"],
-    condo_stat_groups=pd.NA,
+    res_stat_groups=pd.NA,
+    condo_stat_groups=inputs["stat_groups"]["condos"],
     dev_bounds=inputs["dev_bounds"],
     ptax_sd=inputs["ptax_sd"],
     rolling_window=inputs["rolling_window_months"],
@@ -253,23 +253,13 @@ flg.write_to_table(
 )
 """
 # Write to sale.group_mean table
-df_res_single_fam_group_mean = flg.get_group_mean_df(
-    df=df_res_single_fam_flagged,
-    stat_groups=inputs["stat_groups"]["single_family"],
-    run_id=run_id,
-    condos=False,
-)
-
-df_res_multi_group_mean = flg.get_group_mean_df(
-    df=df_res_multi_fam_flagged,
-    stat_groups=inputs["stat_groups"]["multi_family"],
+df_condos_group_mean = flg.get_group_mean_df(
+    df=df_condo_flagged,
+    stat_groups=inputs["stat_groups"]["condos"],
     run_id=run_id,
     condos=True,
 )
 
-df_group_mean_merged = pd.concat(
-    [df_res_single_fam_group_mean, df_res_multi_group_mean]
-).reset_index(drop=True)
 """
 flg.write_to_table(
     df=df_group_mean_merged,

--- a/manual_flagging/yaml/inputs_update.yaml
+++ b/manual_flagging/yaml/inputs_update.yaml
@@ -2,19 +2,12 @@
 # We use these inputs when we want to re-flag already flagged sales.
 ---
 stat_groups:
-  single_family:
+  condos:
     - "rolling_window"
     - "geography_split"
-    - "bldg_age_bin"
-    - "char_bldg_sf_bin"
-  multi_family:
-    - "rolling_window"
-    - "geography_split"
-    - "bldg_age_bin"
 
 iso_forest: [
   "meta_sale_price",
-  "sv_price_per_sqft",
   "sv_days_since_last_transaction",
   "sv_cgdr",
   "sv_sale_dup_counts"


### PR DESCRIPTION
This PR updates the city tri condo flags with the new geography splits from res. This is an admittedly messy, temporary solution to update the flags, similar to the [res equivalent](https://github.com/ccao-data/model-sales-val/commit/f746297d0ae49760754e56902ea241d3f327f253). When the new [architecture updates](https://github.com/ccao-data/model-sales-val/issues/89) are finished we will manually import the metadata from this run into the new structure. Until then, we can use the commit hash from this PR as a way to save some information.

I will also write metadata parquets locally to be uploaded later.