### PR TITLE
Change `ci_*` prefix to `z_ci_*` in Terraform resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ This repository manages the configurations, scripts, and details for an AWS Glue
 2. All changes to these components should originate from this repository. This ensures that every modification is tracked and version-controlled.
 3. The **only** advisable actions in the AWS Console concerning this Glue job are:
     - Running the job
-4. To test a change to the Glue job script or the flagging script, make an edit on a branch and open a pull request. Our GitHub Actions configuration will deploy a staging version of your job, named `ci_<your-branch-name>_sales_val_flagging`, that you can run to test your changes. See the [Modifying the Glue job](#modifying-the-glue-job-its-flagging-script-or-its-settings) section below for more details.
+4. To test a change to the Glue job script or the flagging script, make an edit on a branch and open a pull request. Our GitHub Actions configuration will deploy a staging version of your job, named `z_ci_<your-branch-name>_sales_val_flagging`, that you can run to test your changes. See the [Modifying the Glue job](#modifying-the-glue-job-its-flagging-script-or-its-settings) section below for more details.
 
 ### Modifying the Glue job, its flagging script, or its settings
 
@@ -327,7 +327,7 @@ The Glue job and its flagging script are written in Python, while the job detail
 2. Any changes to these files should be made in the following sequence:
     - Make a new git branch for your changes.
     - Edit the files as necessary.
-    - Open a pull request for your changes against the `main` branch. A GitHub Actions workflow called `deploy-terraform` will deploy a staging version of your job named `ci_<your-branch-name>_sales_val_flagging` that you can run to test your changes.
+    - Open a pull request for your changes against the `main` branch. A GitHub Actions workflow called `deploy-terraform` will deploy a staging version of your job named `z_ci_<your-branch-name>_sales_val_flagging` that you can run to test your changes.
       - By default, this configuration will deploy an empty version of the `sale.flag` table, which simulates an environment in which there are no preexisting flags prior to a run.
       - If you would like to test your job against a subset of the production data, copy your data subset from the production job bucket to the bucket created by Terraform for your job (or leave the new bucket empty to simulate running the job when no flags exist). Then, run the crawler created by Terraform for your PR in order to populate the staging version of the `sale.flag` database that your staging job uses. If you're having trouble finding your staging bucket, job, or crawler, check the GitHub Actions output for the first successful run of your PR and look for the Terraform output displaying the IDs of these resources.
     - If you need to make further changes, push commits to your branch and GitHub Actions will deploy the changes to the staging job and its associated resources.

--- a/main.tf
+++ b/main.tf
@@ -24,8 +24,8 @@ locals {
   s3_prefix                = "scripts/sales-val"
   s3_bucket_data_warehouse = terraform.workspace == "prod" ? "ccao-data-warehouse-us-east-1" : aws_s3_bucket.data_warehouse[0].id
   s3_bucket_glue_assets    = terraform.workspace == "prod" ? "ccao-glue-assets-us-east-1" : aws_s3_bucket.glue_assets[0].id
-  glue_job_name            = terraform.workspace == "prod" ? "sales_val_flagging" : "ci_${terraform.workspace}_sales_val_flagging"
-  glue_crawler_name        = terraform.workspace == "prod" ? "ccao-data-warehouse-sale-crawler" : "ci_${terraform.workspace}_ccao-data-warehouse-sale-crawler"
+  glue_job_name            = terraform.workspace == "prod" ? "sales_val_flagging" : "z_ci_${terraform.workspace}_sales_val_flagging"
+  glue_crawler_name        = terraform.workspace == "prod" ? "ccao-data-warehouse-sale-crawler" : "z_ci_${terraform.workspace}_ccao-data-warehouse-sale-crawler"
   glue_table_sale_flag_parameters = {
     CrawlerSchemaDeserializerVersion = "1.0"
     CrawlerSchemaSerializerVersion   = "1.0"
@@ -42,7 +42,7 @@ locals {
   # (Note that this is not always true -- notably, dbt-athena is able to
   # create Athena tables with hyphens -- but it's a rule that Terraform
   # enforces, so we follow it here)
-  athena_database_name = terraform.workspace == "prod" ? "sale" : "ci_model_sales_val_${replace(terraform.workspace, "-", "_")}_sale"
+  athena_database_name = terraform.workspace == "prod" ? "sale" : "z_ci_model_sales_val_${replace(terraform.workspace, "-", "_")}_sale"
 }
 
 variable "iam_role_arn" {
@@ -66,7 +66,7 @@ resource "aws_s3_bucket" "glue_assets" {
   count = terraform.workspace == "prod" ? 0 : 1
   # Buckets can only be a max of 63 characters long:
   # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-  bucket        = "ccao-ci-${substr(terraform.workspace, 0, 33)}-glue-assets-us-east-1"
+  bucket        = "ccao-z-ci-${substr(terraform.workspace, 0, 33)}-glue-assets-us-east-1"
   force_destroy = true
 }
 
@@ -91,7 +91,7 @@ resource "aws_s3_bucket_versioning" "glue_assets" {
 
 resource "aws_s3_bucket" "data_warehouse" {
   count         = terraform.workspace == "prod" ? 0 : 1
-  bucket        = "ccao-ci-${substr(terraform.workspace, 0, 30)}-data-warehouse-us-east-1"
+  bucket        = "ccao-z-ci-${substr(terraform.workspace, 0, 30)}-data-warehouse-us-east-1"
   force_destroy = true
 }
 

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "aws_s3_bucket" "glue_assets" {
   count = terraform.workspace == "prod" ? 0 : 1
   # Buckets can only be a max of 63 characters long:
   # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-  bucket        = "ccao-z-ci-${substr(terraform.workspace, 0, 31)}-glue-assets-us-east-1"
+  bucket        = "z-ci-ccao-${substr(terraform.workspace, 0, 31)}-glue-assets-us-east-1"
   force_destroy = true
 }
 
@@ -91,7 +91,7 @@ resource "aws_s3_bucket_versioning" "glue_assets" {
 
 resource "aws_s3_bucket" "data_warehouse" {
   count         = terraform.workspace == "prod" ? 0 : 1
-  bucket        = "ccao-z-ci-${substr(terraform.workspace, 0, 28)}-data-warehouse-us-east-1"
+  bucket        = "z-ci-ccao-${substr(terraform.workspace, 0, 28)}-data-warehouse-us-east-1"
   force_destroy = true
 }
 

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "aws_s3_bucket" "glue_assets" {
   count = terraform.workspace == "prod" ? 0 : 1
   # Buckets can only be a max of 63 characters long:
   # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-  bucket        = "ccao-z-ci-${substr(terraform.workspace, 0, 33)}-glue-assets-us-east-1"
+  bucket        = "ccao-z-ci-${substr(terraform.workspace, 0, 31)}-glue-assets-us-east-1"
   force_destroy = true
 }
 
@@ -91,7 +91,7 @@ resource "aws_s3_bucket_versioning" "glue_assets" {
 
 resource "aws_s3_bucket" "data_warehouse" {
   count         = terraform.workspace == "prod" ? 0 : 1
-  bucket        = "ccao-z-ci-${substr(terraform.workspace, 0, 30)}-data-warehouse-us-east-1"
+  bucket        = "ccao-z-ci-${substr(terraform.workspace, 0, 28)}-data-warehouse-us-east-1"
   force_destroy = true
 }
 


### PR DESCRIPTION
This PR updates the prefixes used by the resources defined in the Terraform config to match the convention we use in https://github.com/ccao-data/data-architecture, namely that staging resources get prefixed with `z_ci_*` instead of `ci_*` for better sorting in the AWS UI.

See [here](https://github.com/ccao-data/model-sales-val/actions/runs/8286236192/job/22675921607?pr=109) for an example of a workflow run that successfully sets up resources with the new prefix, and [here](https://github.com/ccao-data/model-sales-val/actions/runs/8286446841/job/22676451090) for an example of an equivalent `cleanup-terraform` run.

Closes https://github.com/ccao-data/model-sales-val/issues/80.