### PR TITLE
Add `scripts/export.py` script for exporting flags to iasWorld

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ venv/
 __pycache__/
 ipynb_checkpoints
 glue/schema/*.parquet
+*.csv
 
 # Terraform internals
 .terraform

--- a/README.md
+++ b/README.md
@@ -339,12 +339,12 @@ The Glue job and its flagging script are written in Python, while the job detail
 
 ## Exporting Flags to iasWorld
 
-Use the `scripts/export.py` script to generate a CSV that can be uploaded to iasWorld to incorporate new flags.
+Use the `scripts/export.py` script to generate a CSV that can be uploaded to iasWorld to save new flags.
 
 Example use:
 
 ```
-python3 scripts/export.py > export.csv
+python3 scripts/export.py > sales_val_flags.csv
 ```
 
-The `example.csv` file can then be sent over for upload to iasWorld.
+The `sales_val_flags.csv` file can then be sent over for upload to iasWorld.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Table of Contents
 - [Flagging Details](#flagging-details)
 - [Structure of Data](#structure-of-data)
 - [AWS Glue Job Documentation](#aws-glue-job-documentation)
+- [Exporting Flags to iasWorld](#exporting-flags-to-iasworld)
 
 ## Model Overview
 
@@ -335,3 +336,15 @@ The Glue job and its flagging script are written in Python, while the job detail
     - If you need to make further changes, push commits to your branch and GitHub Actions will deploy the changes to the staging job and its associated resources.
     - Once you're happy with your changes, request review on your PR.
     - Once your PR is approved, merge it into `main`. A GitHub Actions workflow called `cleanup-terraform` will delete the staging resources that were created for your branch, while a separate `deploy-terraform` run will deploy your changes to the production job and its associated resources.
+
+## Exporting Flags to iasWorld
+
+Use the `scripts/export.py` script to generate a CSV that can be uploaded to iasWorld to incorporate new flags.
+
+Example use:
+
+```
+python3 scripts/export.py > export.csv
+```
+
+The `example.csv` file can then be sent over for upload to iasWorld.

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Export sales val flags to a CSV for upload to iasworld. Outputs to stdout.
+#
+# Example usage:
+#
+#   python3 scripts/export.py > export.csv
+import os
+import sys
+
+import pandas
+import pyathena
+import pyathena.pandas.util
+
+PIN_FIELD = "PARID"
+SALE_KEY_FIELD = "SALEKEY"
+IS_OUTLIER_FIELD = "USER26"
+OUTLIER_TYPE_FIELD = "USER27"
+RUN_ID_FIELD = "USER28"
+ANALYST_DETERMINATION_FIELD = "USER29"
+ANALYST_REVIEW_DATE_FIELD = "UDATE1"
+
+OUTLIER_TYPE_CODES = {
+    "Anomaly (high)": "1",
+    "Anomaly (low)": "2",
+    "Family sale (high)": "3",
+    "Family sale (low)": "4",
+    "High price (raw & sqft)": "5",
+    "High price (raw)": "6",
+    "High price (sqft)": "7",
+    "High price swing": "8",
+    "Home flip sale (high)": "9",
+    "Home flip sale (low)": "10",
+    "Low price (raw & sqft)": "11",
+    "Low price (raw)": "12",
+    "Low price (sqft)": "13",
+    "Low price swing": "14",
+    "Non-person sale (high)": "15",
+    "Non-person sale (low)": "16",
+    "PTAX-203 flag (High)": "17",
+    "PTAX-203 flag (Low)": "17",
+    "Not outlier": pandas.NA,
+}
+
+if __name__ == "__main__":
+    conn = pyathena.connect(
+        s3_staging_dir=os.getenv(
+            "AWS_ATHENA_S3_STAGING_DIR", "s3://ccao-athena-results-us-east-1/"
+        ),
+        region_name=os.getenv("AWS_REGION", "us-east-1"),
+    )
+
+    SQL_QUERY = f"""
+    SELECT
+        sale.pin AS {PIN_FIELD},
+        sale.sale_key AS {SALE_KEY_FIELD},
+        CASE
+            WHEN flag.sv_is_outlier = TRUE
+            THEN 'Y'
+            ELSE 'N'
+        END AS {IS_OUTLIER_FIELD},
+        flag.sv_outlier_type AS {OUTLIER_TYPE_FIELD},
+        flag.run_id AS {RUN_ID_FIELD},
+        'N' AS {ANALYST_DETERMINATION_FIELD},
+        NULL AS {ANALYST_REVIEW_DATE_FIELD}
+    FROM sale.flag AS flag
+    -- Filter flags for the most recent version
+    INNER JOIN (
+        SELECT meta_sale_document_num, MAX(version) AS version
+        FROM sale.flag
+        GROUP BY meta_sale_document_num
+    ) AS flag_latest_version
+        ON flag.meta_sale_document_num = flag_latest_version.meta_sale_document_num
+        AND flag.version = flag_latest_version.version
+    INNER JOIN default.vw_pin_sale AS sale
+        ON flag.meta_sale_document_num = sale.doc_no
+    """
+
+    cursor = conn.cursor()
+    cursor.execute(SQL_QUERY)
+
+    df = pyathena.pandas.util.as_pandas(cursor)
+
+    # Transform outlier type column from string to code
+    df[OUTLIER_TYPE_FIELD] = df[OUTLIER_TYPE_FIELD].replace(OUTLIER_TYPE_CODES)
+
+    # Run some data integrity checks
+    not_null_fields = [PIN_FIELD, SALE_KEY_FIELD, RUN_ID_FIELD]
+    for field in not_null_fields:
+        assert df[df[field].isnull()].empty, f"{field} contains nulls"
+
+    assert df[
+        ~df[OUTLIER_TYPE_FIELD].isin(OUTLIER_TYPE_CODES.values())
+    ].empty, f"{OUTLIER_TYPE_FIELD} contains invalid codes"
+
+    assert df[
+        (df[IS_OUTLIER_FIELD] == 'Y') &
+        (df[OUTLIER_TYPE_FIELD].isna())
+    ].empty, f"{OUTLIER_TYPE_FIELD} cannot be null when {IS_OUTLIER_FIELD} is Y"
+
+    assert df[
+        (df[IS_OUTLIER_FIELD] == 'N') &
+        (~df[OUTLIER_TYPE_FIELD].isna())
+    ].empty, f"{OUTLIER_TYPE_FIELD} must be null when {IS_OUTLIER_FIELD} is N"
+
+    df.to_csv(sys.stdout, index=False, chunksize=10000)

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -93,13 +93,11 @@ if __name__ == "__main__":
     ].empty, f"{OUTLIER_TYPE_FIELD} contains invalid codes"
 
     assert df[
-        (df[IS_OUTLIER_FIELD] == 'Y') &
-        (df[OUTLIER_TYPE_FIELD].isna())
+        (df[IS_OUTLIER_FIELD] == "Y") & (df[OUTLIER_TYPE_FIELD].isna())
     ].empty, f"{OUTLIER_TYPE_FIELD} cannot be null when {IS_OUTLIER_FIELD} is Y"
 
     assert df[
-        (df[IS_OUTLIER_FIELD] == 'N') &
-        (~df[OUTLIER_TYPE_FIELD].isna())
+        (df[IS_OUTLIER_FIELD] == "N") & (~df[OUTLIER_TYPE_FIELD].isna())
     ].empty, f"{OUTLIER_TYPE_FIELD} must be null when {IS_OUTLIER_FIELD} is N"
 
     df.to_csv(sys.stdout, index=False, chunksize=10000)


### PR DESCRIPTION
This PR adds a new script to the repo allowing a caller to export flags to iasWorld for upload.

## Testing

To test, check out the code and run the script:

```
python3 -m venv venv
source venv/bin/activate
pip install -r manual_flagging/requirements.txt
python3 scripts/export.py > sales_val_flags.csv
```

You may have to run `aws-mfa` if you haven't already today.

## Questions

A couple of big-picture design questions about this code:

* Should this script live here in `model-sales-val`, or instead in https://github.com/ccao-data/data-architecture? On the one hand, it largely references data produced by this repo, but on the other hand it represents a type of export that is currently uncommon but that we expect to become more common across our data warehouse in the future. From a code perspective, there's no reason why it needs to live in one repo or the other, but once we start doing exports like this more regularly I wonder if we'll want them all to live in one place.
* What sorts of flags should the script accept for filtering the flag output? And should we implement those now, or wait until we know more about our export cadence? I think it makes sense to wait, but I'm curious what you think in general. Some ideas:
    * Filter by one or more run IDs, so that e.g. we can generate a new run and then only export the flags it created
    * Filter by run date, so we can e.g. export all flags created after a certain date 
    * Any others?

Closes #113.