### PR TITLE
Flip outlier indicator and use longer value fields in `scripts/export.csv`

### DIFF
--- a/scripts/export.py
+++ b/scripts/export.py
@@ -20,6 +20,9 @@ IS_OUTLIER_FIELD = "USER26"
 OUTLIER_TYPE_FIELD = "USER27"
 RUN_ID_FIELD = "USER28"
 
+IS_OUTLIER_INDICATOR = "N: Non arms-length"
+NON_OUTLIER_INDICATOR = "Y: Is arms-length"
+
 OUTLIER_TYPE_CODES = {
     "Not outlier": "0",
     "Anomaly (high)": "1",
@@ -78,8 +81,8 @@ if __name__ == "__main__":
         sale.sale_key AS {SALE_KEY_FIELD},
         CASE
             WHEN flag.sv_is_outlier = TRUE
-            THEN 'Y'
-            ELSE 'N'
+            THEN '{IS_OUTLIER_INDICATOR}'
+            ELSE '{NON_OUTLIER_INDICATOR}'
         END AS {IS_OUTLIER_FIELD},
         flag.sv_outlier_type AS {OUTLIER_TYPE_FIELD},
         flag.run_id AS {RUN_ID_FIELD}
@@ -119,19 +122,19 @@ if __name__ == "__main__":
     ].empty, f"{OUTLIER_TYPE_FIELD} contains invalid codes"
 
     assert flag_df[
-        (flag_df[IS_OUTLIER_FIELD] == "Y")
+        (flag_df[IS_OUTLIER_FIELD] == IS_OUTLIER_INDICATOR)
         & (flag_df[OUTLIER_TYPE_FIELD] == OUTLIER_TYPE_CODES["Not outlier"])
     ].empty, (
-        f"{OUTLIER_TYPE_FIELD} cannot be {OUTLIER_TYPE_CODES['Not outlier']} "
-        f"when {IS_OUTLIER_FIELD} is Y"
+        f"{OUTLIER_TYPE_FIELD} cannot be '{OUTLIER_TYPE_CODES['Not outlier']}' "
+        f"when {IS_OUTLIER_FIELD} is '{IS_OUTLIER_INDICATOR}'"
     )
 
     assert flag_df[
-        (flag_df[IS_OUTLIER_FIELD] == "N")
+        (flag_df[IS_OUTLIER_FIELD] == NON_OUTLIER_INDICATOR)
         & (flag_df[OUTLIER_TYPE_FIELD] != OUTLIER_TYPE_CODES["Not outlier"])
     ].empty, (
-        f"{OUTLIER_TYPE_FIELD} must be {OUTLIER_TYPE_CODES['Not outlier']} "
-        f"when {IS_OUTLIER_FIELD} is N"
+        f"{OUTLIER_TYPE_FIELD} must be '{OUTLIER_TYPE_CODES['Not outlier']}' "
+        f"when {IS_OUTLIER_FIELD} is '{NON_OUTLIER_INDICATOR}'"
     )
 
     assert (


### PR DESCRIPTION
This PR fixes two problems with `scripts/export.csv` introduced in https://github.com/ccao-data/model-sales-val/pull/114 that we noticed after a test upload:

1. Indicator values were flipped incorrectly such that `Y` corresponded to outliers and `N` corresponded to non-outliers, which is the opposite of the export spec
    * This PR flips the use of these fields to match the spec
2. Using the short value for the `Model Determination` field (`Y` or `N`) resulted in the field being writeable after export
    * This PR switches to using the long value to make the fields read-only

## Testing

Test instructions are the same as https://github.com/ccao-data/model-sales-val/pull/114:

```
python3 -m venv venv
source venv/bin/activate
pip install -r manual_flagging/requirements.txt
python3 scripts/export.py > sales_val_flags.csv
```

You may have to run `aws-mfa` if you haven't already today.