### PR TITLE
Add intern names to generator

### DIFF
--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -427,6 +427,10 @@ def finish_flags(df, start_date, manual_update, sales_to_write_filter):
         "jean",
         "damon",
         "michael",
+        "matt",
+        "caroline",
+        "julia",
+        "megan"
     ]
 
     random_words = random.choice(left) + "-" + random.choice(right)

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -430,7 +430,7 @@ def finish_flags(df, start_date, manual_update, sales_to_write_filter):
         "matt",
         "caroline",
         "julia",
-        "megan"
+        "megan",
     ]
 
     random_words = random.choice(left) + "-" + random.choice(right)


### PR DESCRIPTION
Adds recent interns to the name generator for the sales val model. I don't love that this list is now shared across the `ccao` package and this model. I wonder if there's a way we could share it. Maybe use a git submodules. Any thoughts @wagnerlmichael @jeancochrane?