### PR TITLE
Implement design doc changes

### DIFF
--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -742,9 +742,8 @@ def z_normalize_groupby(s: pd.Series):
 
 def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
     """
-    Enhances the dataframe by adding two columns for outlier reasons:
-    - sv_char_outlier_reason: Reasons based on characteristics including price swings.
-    - sv_char_price_reason: Reasons based on high or low pricing levels.
+    This function create indicator columns for each distinct outlier type between price
+    and characteristic outliers. These columns are prefixed with 'sv_ind_'.
 
     Inputs:
         df (pd.DataFrame): Dataframe with necessary columns created from previous functions.

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -828,8 +828,6 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
             .eq("legal_entity")
             .any(axis=1),
             df["sv_anomaly"] == "Outlier",
-            df["sv_pricing"].str.contains("High price swing"),
-            df["sv_anomaly"] == "Outlier",
             df["sv_pricing"].str.contains("High price swing")
             | df["sv_pricing"].str.contains("Low price swing"),
         ]

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -785,21 +785,22 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
     else:
         # Define conditions for price-based reasons
         price_conditions = [
+            (
+                df["sv_pricing"].str.contains("High")
+                & (df["sv_which_price"].str.contains("raw"))
+            ),
+            (
+                df["sv_pricing"].str.contains("Low")
+                & (df["sv_which_price"].str.contains("raw"))
+            ),
             (df["sv_pricing"].str.contains("High"))
-            & (df["sv_which_price"] == "(raw & sqft)"),
+            & (df["sv_which_price"].str.contains("sqft")),
             (df["sv_pricing"].str.contains("Low"))
-            & (df["sv_which_price"] == "(raw & sqft)"),
-            (df["sv_pricing"].str.contains("High") & (df["sv_which_price"] == "(raw)")),
-            (df["sv_pricing"].str.contains("Low") & (df["sv_which_price"] == "(raw)")),
-            (df["sv_pricing"].str.contains("High"))
-            & (df["sv_which_price"] == "(sqft)"),
-            (df["sv_pricing"].str.contains("Low")) & (df["sv_which_price"] == "(sqft)"),
+            & (df["sv_which_price"].str.contains("sqft")),
         ]
 
         # Define labels for price-based reasons
         price_labels = [
-            "sv_ind_price_high_price_raw_and_sqft",
-            "sv_ind_price_low_price_raw_and_sqft",
             "sv_ind_price_high_price",
             "sv_ind_price_low_price",
             "sv_ind_price_high_price_sqft",
@@ -814,25 +815,6 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
     # Create indicator columns for each flag type
     for label, condition in outlier_type_dict.items():
         df[label] = condition.astype(int)
-
-    if not condos:
-        # Separate out combined raw and sqft label to be discrete cols
-        df.loc[
-            df["sv_ind_price_high_price_raw_and_sqft"] == 1,
-            ["sv_ind_price_high_price_sqft", "sv_ind_price_high_price"],
-        ] = 1
-        df.loc[
-            df["sv_ind_price_low_price_raw_and_sqft"] == 1,
-            ["sv_ind_price_low_price_sqft", "sv_ind_price_low_price"],
-        ] = 1
-
-        df.drop(
-            columns=[
-                "sv_ind_price_high_price_raw_and_sqft",
-                "sv_ind_price_low_price_raw_and_sqft",
-            ],
-            inplace=True,
-        )
 
     return df
 

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -786,8 +786,8 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
             .eq("legal_entity")
             .any(axis=1),
             df["sv_anomaly"] == "Outlier",
-            df["sv_pricing"].str.contains("High price swing"),
-            df["sv_pricing"].str.contains("Low price swing"),
+            df["sv_pricing"].str.contains("High price swing")
+            | df["sv_pricing"].str.contains("Low price swing"),
         ]
 
         # Define labels for characteristic-based reasons
@@ -796,8 +796,7 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
             "Family sale",
             "Non-person sale",
             "Statistical anomaly",
-            "High price swing",
-            "Low price swing",
+            "Price Swing / Home flip",
         ]
 
         # Define conditions for price-based reasons
@@ -830,7 +829,9 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
             .any(axis=1),
             df["sv_anomaly"] == "Outlier",
             df["sv_pricing"].str.contains("High price swing"),
-            df["sv_pricing"].str.contains("Low price swing"),
+            df["sv_anomaly"] == "Outlier",
+            df["sv_pricing"].str.contains("High price swing")
+            | df["sv_pricing"].str.contains("Low price swing"),
         ]
 
         # Define labels for characteristic-based reasons
@@ -839,8 +840,7 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
             "Family sale",
             "Non-person sale",
             "Statistical anomaly",
-            "High price swing",
-            "Low price swing",
+            "Price Swing / Home flip",
         ]
 
         # Define conditions for price-based reasons

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -818,23 +818,24 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
     for label, condition in outlier_type_dict.items():
         df[label] = condition.astype(int)
 
-    # Separate out combined raw and sqft label to be discrete cols
-    df.loc[
-        df["sv_ind_price_high_price_raw_and_sqft"] == 1,
-        ["sv_ind_price_high_price_sqft", "sv_ind_price_high_price"],
-    ] = 1
-    df.loc[
-        df["sv_ind_price_low_price_raw_and_sqft"] == 1,
-        ["sv_ind_price_low_price_sqft", "sv_ind_price_low_price"],
-    ] = 1
+    if not condos:
+        # Separate out combined raw and sqft label to be discrete cols
+        df.loc[
+            df["sv_ind_price_high_price_raw_and_sqft"] == 1,
+            ["sv_ind_price_high_price_sqft", "sv_ind_price_high_price"],
+        ] = 1
+        df.loc[
+            df["sv_ind_price_low_price_raw_and_sqft"] == 1,
+            ["sv_ind_price_low_price_sqft", "sv_ind_price_low_price"],
+        ] = 1
 
-    df.drop(
-        columns=[
-            "sv_ind_price_high_price_raw_and_sqft",
-            "sv_ind_price_low_price_raw_and_sqft",
-        ],
-        inplace=True,
-    )
+        df.drop(
+            columns=[
+                "sv_ind_price_high_price_raw_and_sqft",
+                "sv_ind_price_low_price_raw_and_sqft",
+            ],
+            inplace=True,
+        )
 
     return df
 

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -83,12 +83,8 @@ def outlier_taxonomy(df: pd.DataFrame, permut: tuple, groups: tuple, condos: boo
     """
 
     df = check_days(df, SHORT_TERM_OWNER_THRESHOLD)
-
     df = pricing_info(df, permut, groups, condos=condos)
-
     df = outlier_type(df, condos=condos)
-    # df = outlier_flag(df)
-    # df = special_flag(df)
 
     return df
 
@@ -266,26 +262,6 @@ def pricing_info(
 
     if not condos:
         df["sv_which_price"] = df.apply(which_price, args=(holds, groups), axis=1)
-
-    return df
-
-
-def special_flag(df: pd.DataFrame) -> pd.DataFrame:
-    """
-    Creates column that checks whether there is a special flag for this record.
-    Inputs:
-        df (pd.DataFrame): dataframe to add flags onto
-    Outputs:
-        df (pd.DataFrame): dataframe with 'special_flags' column
-    """
-    cond = [
-        (df["sv_name_match"] != "No match"),
-        (df["sv_short_owner"] == "Short-term owner"),
-        (df["sv_transaction_type"] == "legal_entity-legal_entity"),
-    ]
-    labels = ["Family sale", "Home flip sale", "Non-person sale"]
-
-    df["sv_special_flags"] = np.select(cond, labels, default="Not special")
 
     return df
 

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -804,16 +804,16 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
         ]
 
         labels = [
-            "Home flip sale (high)",
+            "Short-term owner (high)",
             "Family sale (high)",
             "Non-person sale (high)",
-            "Anomaly (high)",
+            "Statistical Anomaly (high)",
             "High price swing",
             "High price (raw)",
-            "Home flip sale (low)",
+            "Short-term owner (low)",
             "Family sale (low)",
             "Non-person sale (low)",
-            "Anomaly (low)",
+            "Statistical Anomaly (low)",
             "Low price swing",
             "Low price (raw)",
         ]
@@ -856,18 +856,18 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
         ]
 
         labels = [
-            "Home flip sale (high)",
+            "Short-term owner (high)",
             "Family sale (high)",
             "Non-person sale (high)",
-            "Anomaly (high)",
+            "Statistical anomaly (high)",
             "High price swing",
             "High price (raw & sqft)",
             "High price (raw)",
             "High price (sqft)",
-            "Home flip sale (low)",
+            "Short-term owner sale (low)",
             "Family sale (low)",
             "Non-person sale (low)",
-            "Anomaly (low)",
+            "Statistical anomaly (low)",
             "Low price swing",
             "Low price (raw & sqft)",
             "Low price (raw)",

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -811,9 +811,7 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
 
     outlier_type_dict = dict(zip(combined_labels, combined_conditions))
 
-    """
-    INDICATOR COLS 
-    """
+    # Create indicator columns for each flag type
     for label, condition in outlier_type_dict.items():
         df[label] = condition.astype(int)
 

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -863,34 +863,6 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
     return df
 
 
-"""
-def outlier_flag(df: pd.DataFrame) -> pd.DataFrame:
-
-    Creates a flag that shows whether the record is an
-    outlier (a special flag) according to our outlier taxonomy.
-    Inputs:
-        df (pd.DataFrame): dataframe to create outlier flag
-    Outputs:
-        df (pd.DataFrame): dataframe with 'is_outlier' column
-
-
-    options = ["High price", "Low price", "High price (sqft)", "Low price (sqft)"]
-    pattern = r"\b(?:" + "|".join(map(re.escape, options)) + r")\b"
-
-    df["sv_is_outlier"] = np.select(
-        [
-            df["sv_outlier_reason1"].str.contains(
-                pattern, case=False, na=False, regex=True
-            )
-        ],
-        [1],
-        default=0,
-    )
-
-    return df
-"""
-
-
 # STRING CLEANUP
 
 """

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -746,9 +746,9 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
     and characteristic outliers. These columns are prefixed with 'sv_ind_'.
 
     Inputs:
-        df (pd.DataFrame): Dataframe with necessary columns created from previous functions.
+        df (pd.DataFrame): Dataframe
     Outputs:
-        df (pd.DataFrame): Dataframe with 'sv_char_outlier_reason' and 'sv_char_price_reason' columns.
+        df (pd.DataFrame): Dataframe with indicator columns for each flag type
     """
 
     char_conditions = [

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -842,6 +842,25 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
     for label, condition in outlier_type_dict.items():
         df[label] = condition.astype(int)
 
+    # Apply the conditions
+    df.loc[
+        df["sv_ind_price_high_price_raw_and_sqft"] == 1,
+        ["sv_ind_price_high_price_sqft", "sv_ind_price_high_price"],
+    ] = 1
+    df.loc[
+        df["sv_ind_price_low_price_raw_and_sqft"] == 1,
+        ["sv_ind_price_low_price_sqft", "sv_ind_price_low_price"],
+    ] = 1
+
+    # Drop the combined raw_and_sqft columns
+    df.drop(
+        columns=[
+            "sv_ind_price_high_price_raw_and_sqft",
+            "sv_ind_price_low_price_raw_and_sqft",
+        ],
+        inplace=True,
+    )
+
     return df
 
 

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -842,7 +842,7 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
     for label, condition in outlier_type_dict.items():
         df[label] = condition.astype(int)
 
-    # Apply the conditions
+    # Separate out combined raw and sqft label to be discrete cols
     df.loc[
         df["sv_ind_price_high_price_raw_and_sqft"] == 1,
         ["sv_ind_price_high_price_sqft", "sv_ind_price_high_price"],
@@ -852,7 +852,6 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
         ["sv_ind_price_low_price_sqft", "sv_ind_price_low_price"],
     ] = 1
 
-    # Drop the combined raw_and_sqft columns
     df.drop(
         columns=[
             "sv_ind_price_high_price_raw_and_sqft",

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -810,10 +810,8 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
     combined_conditions = price_conditions + char_conditions
     combined_labels = price_labels + char_labels
 
-    outlier_type_dict = dict(zip(combined_labels, combined_conditions))
-
     # Create indicator columns for each flag type
-    for label, condition in outlier_type_dict.items():
+    for label, condition in zip(combined_labels, combined_conditions):
         df[label] = condition.astype(int)
 
     return df

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -146,9 +146,8 @@ def classify_outliers(df, stat_groups: list, min_threshold):
     """
 
     # Assign sv_outlier_reasons
-    df["sv_outlier_reason1"] = np.nan
-    df["sv_outlier_reason2"] = np.nan
-    df["sv_outlier_reason3"] = np.nan
+    for idx in range(1, 4):
+        df[f"sv_outlier_reason{idx}"] = np.nan
 
     outlier_type_crosswalk = {
         "sv_ind_ptax_flag_w_deviation": "PTAX-203 Exclusion",

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -143,9 +143,6 @@ def group_size_adjustment(df, stat_groups: list, min_threshold):
 
     """
 
-    # - - -
-    #
-    # - - -
     group_counts = df.groupby(stat_groups).size().reset_index(name="count")
     filtered_groups = group_counts[group_counts["count"] <= min_threshold]
 

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -121,7 +121,7 @@ def ptax_adjustment(df, groups, ptax_sd, condos: bool):
 
     df["sv_ind_ptax_flag_w_deviation"] = df["sv_ind_ptax_flag_w_deviation"].astype(int)
 
-    # Adjust order to make _____ function smoother
+    # Adjust order to make classify_outliers function smoother
     ptax_col = df.pop("sv_ind_ptax_flag_w_deviation")
     target_index = df.columns.get_loc("sv_ind_price_high_price")
     df.insert(target_index, "sv_ind_ptax_flag_w_deviation", ptax_col)

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -208,25 +208,25 @@ def classify_outliers(df, stat_groups: list, min_threshold):
     ]
 
     def fill_outlier_reasons(row):
-        reason_idx = 1
         reasons_added = set()  # Set to track reasons already added
 
-        for reason in outlier_type_crosswalk:
-            current_reason = outlier_type_crosswalk[reason]
+        for reason_ind_col in outlier_type_crosswalk:
+            current_reason = outlier_type_crosswalk[reason_ind_col]
             # Add a check to ensure that only specific reasons are added if _merge is not 'both'
             if (
-                reason in row
-                and row[reason]
+                reason_ind_col in row
+                and row[reason_ind_col]
                 and current_reason
                 not in reasons_added  # Check if the reason is already added
                 # Apply group threshold logic
-                and not (row["_merge"] == "both" and reason in group_thresh_price_fix)
+                and not (
+                    row["_merge"] == "both" and reason_ind_col in group_thresh_price_fix
+                )
             ):
-                row[f"sv_outlier_reason{reason_idx}"] = current_reason
+                row[f"sv_outlier_reason{len(reasons_added) + 1}"] = current_reason
                 reasons_added.add(current_reason)  # Add current reason to the set
-                if reason_idx >= 3:
+                if len(reasons_added) >= 3:
                     break
-                reason_idx += 1
 
         return row
 

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -239,7 +239,7 @@ def finish_flags(df, start_date, manual_update, sales_to_write_filter):
                     (df["ptax_flag_w_deviation"]) & (df["ptax_direction"] == "High"),
                     (df["ptax_flag_w_deviation"]) & (df["ptax_direction"] == "Low"),
                 ],
-                ["PTAX-203 flag (High)", "PTAX-203 flag (Low)"],
+                ["PTAX-203 Exclusion (High)", "PTAX-203 Exclusion (Low)"],
                 default=df["sv_outlier_type"],
             ),
         )
@@ -247,7 +247,7 @@ def finish_flags(df, start_date, manual_update, sales_to_write_filter):
             # Change sv_is_outlier to binary
             sv_is_outlier=lambda df: df["sv_outlier_type"] != "Not outlier",
             # PTAX-203 binary
-            sv_is_ptax_outlier=lambda df: df["sv_outlier_type"] == "PTAX-203 flag",
+            sv_is_ptax_outlier=lambda df: "PTAX-203 Exclusion" in df["sv_outlier_type"],
             # Heuristics flagging binary column
             sv_is_heuristic_outlier=lambda df: (
                 df["sv_outlier_type"] != "PTAX-203 flag"

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -157,9 +157,6 @@ def classify_outliers(df, stat_groups: list, min_threshold):
 
     cols_to_iterate = [col for col in df.columns if col.startswith("sv_ind")]
 
-    # - - -
-    # TODO: try numba speed up here
-    # - - -
     def fill_outlier_reasons(row):
         reasons = [
             row[f"sv_outlier_reason{i}"] for i in range(1, 4)

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -192,7 +192,7 @@ def classify_outliers(df, stat_groups: list, min_threshold):
     values_to_check = {
         "PTAX-203 Exclusion",
         "High price",
-        "High price",
+        "Low price",
         "High price per square foot",
         "Low price per square foot",
     }

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -138,7 +138,7 @@ def ptax_adjustment(df, groups, ptax_sd, condos: bool):
         | df["ptax_flag_w_deviation"],
     )
 
-    # First, calculate the new values for sv_outlier_reason1 based on ptax conditions
+    # Calculate the new values for sv_outlier_reason1 based on ptax conditions
     new_sv_outlier_reason1 = np.select(
         [
             (df["ptax_flag_w_deviation"]) & (df["ptax_direction"] == "High"),
@@ -148,27 +148,19 @@ def ptax_adjustment(df, groups, ptax_sd, condos: bool):
         default=df["sv_outlier_reason1"],
     )
 
-    # Then use these new values to update sv_outlier_reason1, and conditionally shift sv_outlier_reason2 and sv_outlier_reason3
+    # Conditionally shift sv_outlier_reason2 and sv_outlier_reason3
     df = df.assign(
         sv_outlier_reason2=lambda df: np.where(
             (new_sv_outlier_reason1 != df["sv_outlier_reason1"])
             & (df["sv_outlier_reason1"] != "Not outlier"),
-            df[
-                "sv_outlier_reason1"
-            ],  # This will now shift the old sv_outlier_reason1 to sv_outlier_reason2
-            df[
-                "sv_outlier_reason2"
-            ],  # Keep the current sv_outlier_reason2 if no shift is needed
+            df["sv_outlier_reason1"],
+            df["sv_outlier_reason2"],
         ),
         sv_outlier_reason3=lambda df: np.where(
             (new_sv_outlier_reason1 != df["sv_outlier_reason1"])
             & (df["sv_outlier_reason1"] != "Not outlier"),
-            df[
-                "sv_outlier_reason2"
-            ],  # This will shift the old sv_outlier_reason2 to sv_outlier_reason3
-            df[
-                "sv_outlier_reason3"
-            ],  # Keep the current sv_outlier_reason3 if no shift is needed
+            df["sv_outlier_reason2"],
+            df["sv_outlier_reason3"],
         ),
     ).assign(
         sv_outlier_reason1=new_sv_outlier_reason1  # Finally update sv_outlier_reason1 with the new values

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -186,7 +186,13 @@ def classify_outliers(df, stat_groups: list, min_threshold):
         "High price per square foot",
         "Low price per square foot",
     }
-    df["sv_is_outlier"] = np.where(df["sv_outlier_reason1"].isin(values_to_check), 1, 0)
+    df["sv_is_outlier"] = np.where(
+        df[
+            ["sv_outlier_reason{idx}" for idx in range(1, 4)]
+        ].isin(values_to_check).any(axis=1), 
+        1, 
+        0
+    )
 
     # - - -
     # Handle group threshold adjustment

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -200,16 +200,11 @@ def finish_flags(df, start_date, manual_update, sales_to_write_filter):
         run_id: unique run_id used for metadata. etc.
         timestamp: unique timestamp for metadata
     """
-    print("0th check")
-    print(df.sv_is_outlier.value_counts())
 
     # Remove duplicate rows
     df = df[df["original_observation"]]
     # Discard pre-2014 data
     df = df[df["meta_sale_date"] >= start_date]
-
-    print("0.5th check")
-    print(df.sv_is_outlier.value_counts())
 
     if sales_to_write_filter["column"]:
         df = df[
@@ -222,9 +217,6 @@ def finish_flags(df, start_date, manual_update, sales_to_write_filter):
         sv_is_outlier=lambda df: df["sv_is_autoval_outlier"]
         | df["ptax_flag_w_deviation"],
     )
-
-    print("First check")
-    print(df.sv_is_outlier.value_counts())
 
     # First, calculate the new values for sv_outlier_reason1 based on ptax conditions
     new_sv_outlier_reason1 = np.select(
@@ -262,9 +254,6 @@ def finish_flags(df, start_date, manual_update, sales_to_write_filter):
         sv_outlier_reason1=new_sv_outlier_reason1  # Finally update sv_outlier_reason1 with the new values
     )
 
-    print("Second check")
-    print(df.sv_is_outlier.value_counts())
-
     df = df.assign(
         # PTAX-203 binary
         sv_is_ptax_outlier=lambda df: df["sv_outlier_reason1"].str.contains(
@@ -277,8 +266,6 @@ def finish_flags(df, start_date, manual_update, sales_to_write_filter):
         & (df["sv_is_outlier"] == 1),
         sv_is_outlier=lambda df: df["sv_is_outlier"].astype(int),
     )
-    print("Third check")
-    print(df.sv_is_outlier.value_counts())
 
     cols_to_write = [
         "meta_sale_document_num",

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -163,20 +163,13 @@ def classify_outliers(df, stat_groups: list, min_threshold):
     }
 
     def fill_outlier_reasons(row):
-        reasons = np.array(
-            [row[f"sv_outlier_reason{i}"] for i in range(1, 4)], dtype=object
-        )
-
-        for col in outlier_type_crosswalk:
-            if row[col]:  # If the condition is True
-                reason = col  # Use column name as reason
-                # Check if reason is not already recorded and there's a np.nan slot to fill
-                if reason not in reasons and pd.isna(reasons).any():
-                    next_index = pd.isna(
-                        reasons
-                    ).argmax()  # Find the index of the first True (NaN)
-                    row[f"sv_outlier_reason{next_index + 1}"] = reason
-                    reasons[next_index] = reason  # Update reasons array
+        reason_idx = 1
+        for reason in outlier_type_crosswalk:
+            if row[reason]:  # If the condition is True
+                row[f"sv_outlier_reason{reason_idx}"] = reason
+                if reason_idx >= 3:
+                    break
+                reason_idx += 1
 
         return row
 

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -90,10 +90,6 @@ def ptax_adjustment(df, groups, ptax_sd, condos: bool):
     range in terms of raw price or price per sqft. It creates the
     new column and preserves the old ptax column.
 
-    We add the ptax information by overwriting sv_outlier_reason1
-    and shift the existing sv_outlier_reason1 to sv_outlier_reason2
-    and shift the existing sv_outlier_reason2 to sv_outlier_reason3.
-
     Inputs:
         df: dataframe after flagging has been done
         groups: stat groups used for outlier classification

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -204,7 +204,7 @@ def classify_outliers(df, stat_groups: list, min_threshold):
 
     # - - -
     # Handle group threshold adjustment
-    # TODO: Explain choice of sv_outlier_reason$n
+    # TODO: Explain choice of sv_outlier_reason$n, do we set all reasons to 0 as well?
     # - - -
 
     group_counts = df.groupby(stat_groups).size().reset_index(name="count")

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -186,12 +186,13 @@ def classify_outliers(df, stat_groups: list, min_threshold):
         "High price per square foot",
         "Low price per square foot",
     }
+
     df["sv_is_outlier"] = np.where(
-        df[
-            ["sv_outlier_reason{idx}" for idx in range(1, 4)]
-        ].isin(values_to_check).any(axis=1), 
-        1, 
-        0
+        df[[f"sv_outlier_reason{idx}" for idx in range(1, 4)]]
+        .isin(values_to_check)
+        .any(axis=1),
+        1,
+        0,
     )
 
     # - - -

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -218,7 +218,9 @@ def classify_outliers(df, stat_groups: list, min_threshold):
                 and row[reason_ind_col]
                 and current_reason
                 not in reasons_added  # Check if the reason is already added
-                # Apply group threshold logic
+                # Apply group threshold logic: `row["_merge"]` will be `both` when the group threshold
+                # is not met, but only price indicators (`group_thresh_price_fix`) should use this threshold,
+                # since ptax indicators don't currently utilize group threshold logic
                 and not (
                     row["_merge"] == "both" and reason_ind_col in group_thresh_price_fix
                 )

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -218,8 +218,8 @@ def classify_outliers(df, stat_groups: list, min_threshold):
         df[[f"sv_outlier_reason{idx}" for idx in range(1, 4)]]
         .isin(values_to_check)
         .any(axis=1),
-        1,
-        0,
+        True,
+        False,
     )
 
     # Add group column to eventually write to athena sale.flag table. Picked up in finish_flags()
@@ -229,10 +229,9 @@ def classify_outliers(df, stat_groups: list, min_threshold):
 
     df = df.assign(
         # PTAX-203 binary
-        sv_is_ptax_outlier=lambda df: df["sv_ind_ptax_flag_w_deviation"],
+        sv_is_ptax_outlier=lambda df: df["sv_ind_ptax_flag_w_deviation"] == 1,
         sv_is_heuristic_outlier=lambda df: (~df["sv_ind_ptax_flag_w_deviation"] == 1)
         & (df["sv_is_outlier"] == 1),
-        sv_is_outlier=lambda df: df["sv_is_outlier"].astype(int),
     )
 
     return df

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -5,7 +5,6 @@ import numpy as np
 import os
 import pandas as pd
 import pytz
-import random
 import re
 import sys
 from pyathena import connect
@@ -270,174 +269,20 @@ def finish_flags(df, start_date, manual_update, sales_to_write_filter):
     ]
 
     # Create run_id
+    left = pd.read_csv(
+        "https://raw.githubusercontent.com/ccao-data/data-architecture/master/dbt/seeds/ccao/ccao.adjective.csv"
+    )
+    right = pd.read_csv(
+        "https://raw.githubusercontent.com/ccao-data/data-architecture/master/dbt/seeds/ccao/ccao.person.csv"
+    )
 
-    left = [
-        "activist",
-        "admiring",
-        "adoring",
-        "affectionate",
-        "agitated",
-        "amazing",
-        "angry",
-        "awesome",
-        "beautiful",
-        "blissful",
-        "bold",
-        "boring",
-        "brave",
-        "busy",
-        "charming",
-        "clever",
-        "cool",
-        "compassionate",
-        "competent",
-        "condescending",
-        "confident",
-        "cranky",
-        "crazy",
-        "dazzling",
-        "determined",
-        "distracted",
-        "dreamy",
-        "eager",
-        "ecstatic",
-        "elastic",
-        "elated",
-        "elegant",
-        "eloquent",
-        "epic",
-        "exciting",
-        "fancy-free",
-        "fervent",
-        "festive",
-        "flamboyant",
-        "focused",
-        "footloose",
-        "friendly",
-        "frosty",
-        "funny",
-        "gallant",
-        "gifted",
-        "goofy",
-        "gracious",
-        "great",
-        "happy",
-        "hardcore",
-        "heuristic",
-        "hopeful",
-        "hungry",
-        "infallible",
-        "inspiring",
-        "interesting",
-        "intelligent",
-        "jolly",
-        "jovial",
-        "keen",
-        "kind",
-        "laughing",
-        "loving",
-        "lucid",
-        "magical",
-        "malingering",
-        "mystifying",
-        "modest",
-        "musing",
-        "naughty",
-        "nervous",
-        "nice",
-        "nifty",
-        "nostalgic",
-        "objective",
-        "over-qualified",
-        "optimistic",
-        "peaceful",
-        "pedantic",
-        "pensive",
-        "practical",
-        "priceless",
-        "quirky",
-        "quizzical",
-        "rebellious",
-        "recursing",
-        "relaxed",
-        "reverent",
-        "romantic",
-        "sad",
-        "serene",
-        "sharp",
-        "silly",
-        "sleepy",
-        "stoic",
-        "strange",
-        "stupefied",
-        "suspicious",
-        "sweet",
-        "tender",
-        "thirsty",
-        "trusting",
-        "unruffled",
-        "upbeat",
-        "vibrant",
-        "vigilant",
-        "vigorous",
-        "wizardly",
-        "wonderful",
-        "xenodochial",
-        "youthful",
-        "zealous",
-        "zen",
-    ]
-
-    # Honorary list of Data Department employees, interns, and fellows
-    right = [
-        "billy",
-        "sam",
-        "nicole",
-        "dan",
-        "manasi",
-        "gabe",
-        "patrick",
-        "carly",
-        "jacob",
-        "nathan",
-        "tristan",
-        "eric",
-        "tayun",
-        "kyra",
-        "mike",
-        "antonia",
-        "ida",
-        "ethan",
-        "sean",
-        "matt",
-        "liz",
-        "takuya",
-        "boni",
-        "maya",
-        "damani",
-        "iris",
-        "bowen",
-        "yuxin",
-        "christian",
-        "rina",
-        "rob",
-        "sam",
-        "irene",
-        "claire",
-        "jean",
-        "damon",
-        "michael",
-        "matt",
-        "caroline",
-        "julia",
-        "megan",
-    ]
-
-    random_words = random.choice(left) + "-" + random.choice(right)
+    adj_name_combo = (
+        np.random.choice(left["adjective"]) + "-" + np.random.choice(right["person"])
+    )
     timestamp = datetime.datetime.now(pytz.timezone("America/Chicago")).strftime(
         "%Y-%m-%d_%H:%M"
     )
-    run_id = timestamp + "-" + random_words
+    run_id = timestamp + "-" + adj_name_combo
 
     # Control flow for incorporating versioning
     dynamic_assignment = {

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -235,7 +235,6 @@ def classify_outliers(df, stat_groups: list, min_threshold):
     df = df_flagged_updated.assign(
         # PTAX-203 binary
         sv_is_ptax_outlier=lambda df: df["sv_ind_ptax_flag_w_deviation"],
-        na=False,
         sv_is_heuristic_outlier=lambda df: (
             ~df["sv_outlier_reason1"].str.contains("PTAX-203", na=False)
         )

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -190,6 +190,20 @@ def classify_outliers(df, stat_groups: list, min_threshold):
         "sv_ind_char_price_swing_homeflip": "Price swing / Home flip",
     }
 
+    """
+    During our statistical flagging process, we automatically discard
+    a sale's eligibility for outlier status if the number of sales in 
+    the statistical grouping is below a certain threshold. The list - 
+    `group_thresh_price_fix` along with the ['_merge'] column will allow
+    us to exlude these sales for the sv_is_outlier status.
+
+    Since the `sv_is_outlier` column requires a price value, we simply
+    do not assign these price outlier flags if the group number is below a certain
+    threshold
+
+    Note: This doesn't apply for sales that also have a ptax outlier status.
+          In this case, we still assign the price outlier status.
+    """
     group_thresh_price_fix = [
         "sv_ind_price_high_price",
         "sv_ind_price_low_price",
@@ -209,6 +223,7 @@ def classify_outliers(df, stat_groups: list, min_threshold):
                 and row[reason]
                 and current_reason
                 not in reasons_added  # Check if the reason is already added
+                # Apply group threshold logic
                 and not (row["_merge"] == "both" and reason in group_thresh_price_fix)
             ):
                 row[f"sv_outlier_reason{reason_idx}"] = current_reason
@@ -226,7 +241,6 @@ def classify_outliers(df, stat_groups: list, min_threshold):
 
     # Assign outlier status
     values_to_check = {
-        # "PTAX-203 Exclusion",
         "High price",
         "Low price",
         "High price per square foot",

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -235,9 +235,7 @@ def classify_outliers(df, stat_groups: list, min_threshold):
     df = df_flagged_updated.assign(
         # PTAX-203 binary
         sv_is_ptax_outlier=lambda df: df["sv_ind_ptax_flag_w_deviation"],
-        sv_is_heuristic_outlier=lambda df: (
-            ~df["sv_outlier_reason1"].str.contains("PTAX-203", na=False)
-        )
+        sv_is_heuristic_outlier=lambda df: (~df["sv_ind_ptax_flag_w_deviation"] == 1)
         & (df["sv_is_outlier"] == 1),
         sv_is_outlier=lambda df: df["sv_is_outlier"].astype(int),
     )

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -157,10 +157,6 @@ def classify_outliers(df, stat_groups: list, min_threshold):
 
     """
 
-    # - - -
-    # Handle group threshold adjustment
-    # TODO: Explain choice of sv_outlier_reason$n, do we set all reasons to 0 as well?
-    # - - -
     group_counts = df.groupby(stat_groups).size().reset_index(name="count")
     filtered_groups = group_counts[group_counts["count"] <= min_threshold]
 

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -195,7 +195,7 @@ def classify_outliers(df, stat_groups: list, min_threshold):
     a sale's eligibility for outlier status if the number of sales in 
     the statistical grouping is below a certain threshold. The list - 
     `group_thresh_price_fix` along with the ['_merge'] column will allow
-    us to exlude these sales for the sv_is_outlier status.
+    us to exclude these sales for the sv_is_outlier status.
 
     Since the `sv_is_outlier` column requires a price value, we simply
     do not assign these price outlier flags if the group number is below a certain

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -175,10 +175,10 @@ def classify_outliers(df, stat_groups: list, min_threshold):
     }
 
     group_thresh_price_fix = [
-        "sv_ind_price_high_price"
-        "sv_ind_price_low_price"
-        "sv_ind_price_high_price_sqft"
-        "sv_ind_price_low_price_sqft"
+        "sv_ind_price_high_price",
+        "sv_ind_price_low_price",
+        "sv_ind_price_high_price_sqft",
+        "sv_ind_price_low_price_sqft",
     ]
 
     def fill_outlier_reasons(row):
@@ -194,6 +194,7 @@ def classify_outliers(df, stat_groups: list, min_threshold):
                 if reason_idx >= 3:
                     break
                 reason_idx += 1
+
         return row
 
     df = df.apply(fill_outlier_reasons, axis=1)
@@ -213,7 +214,6 @@ def classify_outliers(df, stat_groups: list, min_threshold):
         "Low price per square foot",
     }
 
-    # Create actual sv_is_outlier column
     df["sv_is_outlier"] = np.where(
         df[[f"sv_outlier_reason{idx}" for idx in range(1, 4)]]
         .isin(values_to_check)

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -151,25 +151,27 @@ def classify_outliers(df, stat_groups: list, min_threshold):
     """
 
     # Assign sv_outlier_reasons
-    df["sv_outlier_reason1"] = "Null"
-    df["sv_outlier_reason2"] = "Null"
-    df["sv_outlier_reason3"] = "Null"
+    df["sv_outlier_reason1"] = np.nan
+    df["sv_outlier_reason2"] = np.nan
+    df["sv_outlier_reason3"] = np.nan
 
     cols_to_iterate = [col for col in df.columns if col.startswith("sv_ind")]
 
     def fill_outlier_reasons(row):
-        reasons = [
-            row[f"sv_outlier_reason{i}"] for i in range(1, 4)
-        ]  # Collect current reasons
+        reasons = np.array(
+            [row[f"sv_outlier_reason{i}"] for i in range(1, 4)], dtype=object
+        )
 
         for col in cols_to_iterate:
             if row[col]:  # If the condition is True
                 reason = col  # Use column name as reason
-                # Check if reason is not already recorded and there's a 'Null' slot to fill
-                if reason not in reasons and "Null" in reasons:
-                    next_index = reasons.index("Null") + 1  # Find the next 'Null' index
-                    row[f"sv_outlier_reason{next_index}"] = reason
-                    reasons[next_index - 1] = reason  # Update reasons list
+                # Check if reason is not already recorded and there's a np.nan slot to fill
+                if reason not in reasons and pd.isna(reasons).any():
+                    next_index = pd.isna(
+                        reasons
+                    ).argmax()  # Find the index of the first True (NaN)
+                    row[f"sv_outlier_reason{next_index + 1}"] = reason
+                    reasons[next_index] = reason  # Update reasons array
 
         return row
 

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -244,10 +244,6 @@ def group_size_adjustment(df, stat_groups: list, min_threshold, condos: bool):
     condition = (merged_df["_merge"] == "both") & (merged_df["sv_is_outlier"] == 1)
 
     # Using .loc[] to set the desired values for rows meeting the condition
-    # TODO: Explain the choice here
-    # merged_df.loc[condition, "sv_outlier_type"] = "Not outlier"
-    # merged_df.loc[condition, "sv_outlier_type"] = "Not outlier"
-    # merged_df.loc[condition, "sv_outlier_type"] = "Not outlier"
     merged_df.loc[condition, "sv_is_outlier"] = 0
 
     # Drop the _merge column

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -117,7 +117,7 @@ def ptax_adjustment(df, groups, ptax_sd, condos: bool):
 
     df["sv_ind_ptax_flag_w_deviation"] = df["sv_ind_ptax_flag_w_deviation"].astype(int)
 
-    # Adjust order to make classify_outliers function smoother
+    # Adjust order of indicator columns to make classify_outliers function smoother
     ptax_col = df.pop("sv_ind_ptax_flag_w_deviation")
     target_index = df.columns.get_loc("sv_ind_price_high_price")
     df.insert(target_index, "sv_ind_ptax_flag_w_deviation", ptax_col)

--- a/manual_flagging/flagging.py
+++ b/manual_flagging/flagging.py
@@ -316,17 +316,17 @@ for df_name, df_info in dfs_flagged.items():
     print(f"\n Enacting group threshold and creating ptax data for {df_name}")
     df_copy = df_info["df"].copy()
 
-    # df_copy = flg.classify_outliers(
-    #    df=df_copy,
-    #    stat_groups=df_info["columns"],
-    #    min_threshold=inputs["min_groups_threshold"],
-    # )
-
     df_copy = flg.ptax_adjustment(
         df=df_copy,
         groups=df_info["columns"],
         ptax_sd=inputs["ptax_sd"],
         condos=df_info["condos_boolean"],
+    )
+
+    df_copy = flg.classify_outliers(
+        df=df_copy,
+        stat_groups=df_info["columns"],
+        min_threshold=inputs["min_groups_threshold"],
     )
 
     # TODO: need to add the classification function

--- a/manual_flagging/flagging.py
+++ b/manual_flagging/flagging.py
@@ -316,17 +316,17 @@ for df_name, df_info in dfs_flagged.items():
     print(f"\n Enacting group threshold and creating ptax data for {df_name}")
     df_copy = df_info["df"].copy()
 
-    df_copy = flg.ptax_adjustment(
-        df=df_copy,
-        groups=df_info["columns"],
-        ptax_sd=inputs["ptax_sd"],
-        condos=df_info["condos_boolean"],
-    )
-
     df_copy = flg.group_size_adjustment(
         df=df_copy,
         stat_groups=df_info["columns"],
         min_threshold=inputs["min_groups_threshold"],
+        condos=df_info["condos_boolean"],
+    )
+
+    df_copy = flg.ptax_adjustment(
+        df=df_copy,
+        groups=df_info["columns"],
+        ptax_sd=inputs["ptax_sd"],
         condos=df_info["condos_boolean"],
     )
 

--- a/manual_flagging/flagging.py
+++ b/manual_flagging/flagging.py
@@ -320,7 +320,6 @@ for df_name, df_info in dfs_flagged.items():
         df=df_copy,
         stat_groups=df_info["columns"],
         min_threshold=inputs["min_groups_threshold"],
-        condos=df_info["condos_boolean"],
     )
 
     df_copy = flg.ptax_adjustment(

--- a/manual_flagging/flagging.py
+++ b/manual_flagging/flagging.py
@@ -315,18 +315,21 @@ for df_name, df_info in dfs_flagged.items():
     # Make a copy of the data frame to edit
     print(f"\n Enacting group threshold and creating ptax data for {df_name}")
     df_copy = df_info["df"].copy()
-    df_copy = flg.group_size_adjustment(
-        df=df_copy,
-        stat_groups=df_info["columns"],
-        min_threshold=inputs["min_groups_threshold"],
-        condos=df_info["condos_boolean"],
-    )
+
     df_copy = flg.ptax_adjustment(
         df=df_copy,
         groups=df_info["columns"],
         ptax_sd=inputs["ptax_sd"],
         condos=df_info["condos_boolean"],
     )
+
+    df_copy = flg.group_size_adjustment(
+        df=df_copy,
+        stat_groups=df_info["columns"],
+        min_threshold=inputs["min_groups_threshold"],
+        condos=df_info["condos_boolean"],
+    )
+
     """
     Modify the 'group' column by appending '-market_value', this is done
     to make sure that a two different groups with the same run_id won't

--- a/manual_flagging/flagging.py
+++ b/manual_flagging/flagging.py
@@ -329,8 +329,6 @@ for df_name, df_info in dfs_flagged.items():
         min_threshold=inputs["min_groups_threshold"],
     )
 
-    # TODO: need to add the classification function
-
     """
     Modify the 'group' column by appending '-market_value', this is done
     to make sure that a two different groups with the same run_id won't

--- a/manual_flagging/flagging.py
+++ b/manual_flagging/flagging.py
@@ -316,11 +316,11 @@ for df_name, df_info in dfs_flagged.items():
     print(f"\n Enacting group threshold and creating ptax data for {df_name}")
     df_copy = df_info["df"].copy()
 
-    df_copy = flg.group_size_adjustment(
-        df=df_copy,
-        stat_groups=df_info["columns"],
-        min_threshold=inputs["min_groups_threshold"],
-    )
+    # df_copy = flg.group_size_adjustment(
+    #    df=df_copy,
+    #    stat_groups=df_info["columns"],
+    #    min_threshold=inputs["min_groups_threshold"],
+    # )
 
     df_copy = flg.ptax_adjustment(
         df=df_copy,
@@ -328,6 +328,8 @@ for df_name, df_info in dfs_flagged.items():
         ptax_sd=inputs["ptax_sd"],
         condos=df_info["condos_boolean"],
     )
+
+    # TODO: need to add the classification function
 
     """
     Modify the 'group' column by appending '-market_value', this is done

--- a/manual_flagging/flagging.py
+++ b/manual_flagging/flagging.py
@@ -316,7 +316,7 @@ for df_name, df_info in dfs_flagged.items():
     print(f"\n Enacting group threshold and creating ptax data for {df_name}")
     df_copy = df_info["df"].copy()
 
-    # df_copy = flg.group_size_adjustment(
+    # df_copy = flg.classify_outliers(
     #    df=df_copy,
     #    stat_groups=df_info["columns"],
     #    min_threshold=inputs["min_groups_threshold"],

--- a/manual_flagging/requirements.txt
+++ b/manual_flagging/requirements.txt
@@ -1,4 +1,4 @@
-awswrangler==2.20.1
+awswrangler==3.7.3
 boto3==1.28.26
 botocore==1.31.26
 certifi==2023.7.22

--- a/manual_flagging/yaml/inputs.yaml
+++ b/manual_flagging/yaml/inputs.yaml
@@ -13,7 +13,7 @@ run_note: |
 # without flags, it assigns a version number of "1". The latest
 # version of each sale flag can be found in the "default"."vw_pin_sale" view.
 
-manual_update: false
+manual_update: true
 
 # "housing_market_type" and "run_tri" configurations determine the
 # specificity of flagging. First, we retrieve the run tris, then run
@@ -25,7 +25,6 @@ housing_market_type: [
   "res_multi_family",
   "res_all",
   "condos"
-
 ]
 run_tri: [1, 2, 3]
 

--- a/manual_flagging/yaml/inputs.yaml
+++ b/manual_flagging/yaml/inputs.yaml
@@ -13,7 +13,7 @@ run_note: |
 # without flags, it assigns a version number of "1". The latest
 # version of each sale flag can be found in the "default"."vw_pin_sale" view.
 
-manual_update: true
+manual_update: false
 
 # "housing_market_type" and "run_tri" configurations determine the
 # specificity of flagging. First, we retrieve the run tris, then run
@@ -22,11 +22,9 @@ manual_update: true
 # "tri$n" value.
 housing_market_type: [
   "res_single_family",
-  "res_multi_family",
-  "res_all",
-  "condos"
+
 ]
-run_tri: [1, 2, 3]
+run_tri: [1]
 
 # "sales_to_write" filter allows further specificity. Here we can decide
 # which flags we want to write at a more precise level than market type
@@ -145,7 +143,7 @@ dev_bounds: [2, 2]
 # sale.flag table. Leave 'end' blank if we want to flag all sales
 # since the start date
 time_frame:
-  start: "2014-01-01"
+  start: "2022-01-01"
   end:
 
 # How many total months to include in the grouping methodology

--- a/manual_flagging/yaml/inputs.yaml
+++ b/manual_flagging/yaml/inputs.yaml
@@ -22,9 +22,12 @@ manual_update: false
 # "tri$n" value.
 housing_market_type: [
   "res_single_family",
+  "res_multi_family",
+  "res_all",
+  "condos"
 
 ]
-run_tri: [1]
+run_tri: [1, 2, 3]
 
 # "sales_to_write" filter allows further specificity. Here we can decide
 # which flags we want to write at a more precise level than market type
@@ -143,7 +146,7 @@ dev_bounds: [2, 2]
 # sale.flag table. Leave 'end' blank if we want to flag all sales
 # since the start date
 time_frame:
-  start: "2022-01-01"
+  start: "2014-01-01"
   end:
 
 # How many total months to include in the grouping methodology


### PR DESCRIPTION
This PR handles https://github.com/ccao-data/model-sales-val/issues/125 and https://github.com/ccao-data/model-sales-val/issues/124.

Essentially I take the existing system and make changes such that it fits with these issues and the new design doc. 

The biggest change here is that we remove `sv_outlier_type` and introduce 3 columns:
- `sv_outlier_reason1`
- `sv_outlier_reason2`
- `sv_outlier_reason3`

In the existing set up, if we have an outlier that is classified , then `sv_outlier_type()` must be one of the following:
- A price outlier defined by the `dev_bounds: [2, 2]` definition in `params.yaml`
- Above price outlier + a characteristic reason determined in the `outlier_type()` function in `glue/flagging_script_glue/flagging.py`. 
- One of the ptax questions flagged and a price deviation from `ptax_sd: [1, 1]`defined in `params.yaml`

The following changes are implemented in order to maintain the existing specs and bring in the new structure. In `sv_outlier_type()` the price and characteristic outlier types are split into `char_conditions`/`char_labels` and `price_conditions`/`price_labels`. 

For the three `sv_outlier_reason$n` columns, we populate them with the following order of priority

1. PTAX-203 Exclusion
2. Price label
3. Char label

Then, we assign the observation as an outlier only if `sv_is_outlier1` is a price label or a ptax label. This allows us to retain sales validation information even if we don't want to technically classify the sale as an outlier. Here are some scenarios:

Scenario 1:
- Outlier  Classification: True
- `sv_outlier_reason1` - High Price
- `sv_outlier_reason2` - High Price (sqft)
- `sv_outlier_reason3` - Non-person sale

Scenario 2:
- Outlier  Classification: False
- `sv_outlier_reason1` - Non-person sale
- `sv_outlier_reason2` - Statistical anomaly
- `sv_outlier_reason3` - null
