### PR TITLE
Fix threshold outlier types

### DIFF
--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -160,26 +160,8 @@ def group_size_adjustment(df, stat_groups: list, min_threshold, condos: bool):
         df, filtered_groups[stat_groups], on=stat_groups, how="left", indicator=True
     )
 
-    # List of sv_outlier_type values to check
-    if condos == False:
-        outlier_types_to_check = [
-            "Low price (raw & sqft)",
-            "Low price (raw)",
-            "Low price (sqft)",
-            "High price (raw & sqft)",
-            "High price (raw)",
-            "High price (sqft)",
-        ]
-    else:
-        outlier_types_to_check = [
-            "Low price (raw)",
-            "High price (raw)",
-        ]
-
     # Modify the .loc condition to include checking for sv_outlier_type values
-    condition = (merged_df["_merge"] == "both") & (
-        merged_df["sv_outlier_type"].isin(outlier_types_to_check)
-    )
+    condition = (merged_df["_merge"] == "both") & (merged_df["sv_is_outlier"] == 1)
 
     # Using .loc[] to set the desired values for rows meeting the condition
     merged_df.loc[condition, "sv_outlier_type"] = "Not outlier"


### PR DESCRIPTION
This PR addresses an issue in the `get_group_threshold()` function within the sales validation pipeline. Previously, we were setting the `sv_outlier_type` values to `Not outlier` only for certain values of `sv_outlier_type`.  

When we run the statistical flagging within a certain group that was below our `min_groups_threshold` defined in `inputs.yaml`, we should ideally be setting all non-ptax outliers to `Not outlier`. However, this was only happening for certain `sv_outlier_type` values. This resulted in some observations incorrectly being flagged as outliers when the number of observations in the group they belonged to was below the `min_group_threshold`.

The fix ensures that all observations in such groups are now consistently marked as `Not outlier`. This excludes ptax outliers, for which we forego the group threshold.