### PR TITLE
Migrate data based on 2024 Q2 Sales Val re-design

### DIFF
--- a/manual_flagging/flagging.py
+++ b/manual_flagging/flagging.py
@@ -327,7 +327,6 @@ for df_name, df_info in dfs_flagged.items():
         ptax_sd=inputs["ptax_sd"],
         condos=df_info["condos_boolean"],
     )
-
     """
     Modify the 'group' column by appending '-market_value', this is done
     to make sure that a two different groups with the same run_id won't

--- a/manual_flagging/flagging.py
+++ b/manual_flagging/flagging.py
@@ -315,18 +315,17 @@ for df_name, df_info in dfs_flagged.items():
     # Make a copy of the data frame to edit
     print(f"\n Enacting group threshold and creating ptax data for {df_name}")
     df_copy = df_info["df"].copy()
-
+    df_copy = flg.group_size_adjustment(
+        df=df_copy,
+        stat_groups=df_info["columns"],
+        min_threshold=inputs["min_groups_threshold"],
+        condos=df_info["condos_boolean"],
+    )
     df_copy = flg.ptax_adjustment(
         df=df_copy,
         groups=df_info["columns"],
         ptax_sd=inputs["ptax_sd"],
         condos=df_info["condos_boolean"],
-    )
-
-    df_copy = flg.classify_outliers(
-        df=df_copy,
-        stat_groups=df_info["columns"],
-        min_threshold=inputs["min_groups_threshold"],
     )
 
     """

--- a/manual_flagging/flagging.py
+++ b/manual_flagging/flagging.py
@@ -315,18 +315,20 @@ for df_name, df_info in dfs_flagged.items():
     # Make a copy of the data frame to edit
     print(f"\n Enacting group threshold and creating ptax data for {df_name}")
     df_copy = df_info["df"].copy()
-    df_copy = flg.group_size_adjustment(
-        df=df_copy,
-        stat_groups=df_info["columns"],
-        min_threshold=inputs["min_groups_threshold"],
-        condos=df_info["condos_boolean"],
-    )
+
     df_copy = flg.ptax_adjustment(
         df=df_copy,
         groups=df_info["columns"],
         ptax_sd=inputs["ptax_sd"],
         condos=df_info["condos_boolean"],
     )
+
+    df_copy = flg.classify_outliers(
+        df=df_copy,
+        stat_groups=df_info["columns"],
+        min_threshold=inputs["min_groups_threshold"],
+    )
+
     """
     Modify the 'group' column by appending '-market_value', this is done
     to make sure that a two different groups with the same run_id won't

--- a/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
+++ b/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
@@ -91,12 +91,12 @@ dfs_flag = read_parquet_files_from_s3(
 
 recode_dict = {
     "PTAX-203 flag (Low)": {
-        "sv_outlier_reason1": "PTAX-203 Exclusion",
-        "sv_outlier_reason2": np.nan,
+        "sv_outlier_reason1": "Low price",
+        "sv_outlier_reason2": "PTAX-203 Exclusion",
     },
     "PTAX-203 flag (High)": {
-        "sv_outlier_reason1": "PTAX-203 Exclusion",
-        "sv_outlier_reason2": np.nan,
+        "sv_outlier_reason1": "High price",
+        "sv_outlier_reason2": "PTAX-203 Exclusion",
     },
     "Non-person sale (low)": {
         "sv_outlier_reason1": "Low price",

--- a/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
+++ b/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
@@ -122,7 +122,7 @@ recode_dict = {
         "sv_outlier_reason1": "Low price",
         "sv_outlier_reason2": "Statistical Anomaly",
     },
-    "Low Price (raw & sqft)": {
+    "Low price (raw & sqft)": {
         "sv_outlier_reason1": "Low price",
         "sv_outlier_reason2": "Low price per square foot",
     },

--- a/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
+++ b/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
@@ -142,7 +142,7 @@ recode_dict = {
         "sv_outlier_reason1": "High price",
         "sv_outlier_reason2": "Price swing / Home flip",
     },
-    "Home flipe sale (low)": {
+    "Home flip sale (low)": {
         "sv_outlier_reason1": "Low price",
         "sv_outlier_reason2": "Price swing / Home flip",
     },

--- a/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
+++ b/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
@@ -1,0 +1,70 @@
+import awswrangler as wr
+import boto3
+import os
+import subprocess as sp
+
+# Set working dir to manual_update, standardize yaml and src locations
+root = sp.getoutput("git rev-parse --show-toplevel")
+os.chdir(os.path.join(root))
+
+
+def read_parquet_files_from_s3(input_path):
+    """
+    Reads all Parquet files from a specified S3 path into a dictionary of DataFrames.
+
+    Parameters:
+        input_path (str): The S3 bucket path where Parquet files are stored, e.g., 's3://my-bucket/my-folder/'
+
+    Returns:
+        dict: A dictionary where each key is the filename and the value is the corresponding DataFrame.
+    """
+    # Initialize the S3 session
+    session = boto3.Session()
+
+    # List all objects in the given S3 path that are Parquet files
+    s3_objects = wr.s3.list_objects(path=input_path, boto3_session=session)
+
+    # Filter objects to get only parquet files
+    parquet_files = [obj for obj in s3_objects if obj.endswith(".parquet")]
+
+    # Dictionary to store DataFrames
+    dataframes = {}
+
+    # Read each Parquet file into a DataFrame and store it in the dictionary
+    for file_path in parquet_files:
+        # Read the Parquet file into a DataFrame
+        df = wr.s3.read_parquet(path=file_path, boto3_session=session)
+
+        # Extract the filename without the path for use as the dictionary key
+        filename = file_path.split("/")[-1].replace(".parquet", "")
+
+        # Add the DataFrame to the dictionary
+        dataframes[filename] = df
+
+    return dataframes
+
+
+dfs_flag = read_parquet_files_from_s3(
+    os.path.join(
+        os.getenv("AWS_S3_WAREHOUSE_BUCKET"),
+        "sale",
+        "flag",
+    )
+)
+
+for i in dfs_flag:
+    print(i)
+
+
+dfs_flag["2024-01-19_18:46-clever-boni"].sv_outlier_type.value_counts()
+
+# "PTAX-203 Exclusion (High)", "PTAX-203 Exclusion (Low)"
+"""
+Characteristic reasons
+Short-term owner
+PTAX-203 Exclusion
+Family sale
+Non-person sale
+Statistical Anomaly
+Price swing / Home Flip
+"""

--- a/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
+++ b/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
@@ -126,7 +126,7 @@ recode_dict = {
         "sv_outlier_reason1": "Low price",
         "sv_outlier_reason2": "Low price per square foot",
     },
-    "High price (raw and sqft)": {
+    "High price (raw & sqft)": {
         "sv_outlier_reason1": "High price",
         "sv_outlier_reason2": "High price per square foot",
     },

--- a/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
+++ b/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
@@ -68,3 +68,14 @@ Non-person sale
 Statistical Anomaly
 Price swing / Home Flip
 """
+
+recode_dict = {
+    "PTAX-203 flag (Low)": {
+        "sv_outlier_reason1": "PTAX-203 Exclusion",
+        "sv_outlier_reason2": "null",
+    },
+    "Non-person sale (low)": {
+        "sv_outlier_reason1": "Low Price",
+        "sv_outlier_reason2": "Non-person sale",
+    },
+}

--- a/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
+++ b/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
@@ -58,11 +58,13 @@ def process_dataframe(df, recode_dict):
         df.insert(pos, f"sv_outlier_reason{i}", np.nan)
         pos += 1
 
+    print(df.dtypes)
     # Use the dictionary to populate the new columns
     for key, value in recode_dict.items():
         mask = df["sv_outlier_type"] == key
         for col, val in value.items():
             df.loc[mask, col] = val
+    print(df.dtypes)
 
     df = df.drop(columns=["sv_outlier_type"])
 
@@ -76,7 +78,9 @@ def write_dfs_to_s3(dfs, bucket, table):
 
     for df_name, df in dfs.items():
         file_path = f"{bucket}/0002_update_outlier_column_structure_w_iasworld_2024_update/new_prod_data/{table}/{df_name}.parquet"
-        wr.s3.to_parquet(df=df, path=file_path, index=False)
+        wr.s3.to_parquet(
+            df=df, path=file_path, index=False, dtype={"sv_outlier_reason3": "string"}
+        )
 
 
 dfs_flag = read_parquet_files_from_s3(
@@ -86,12 +90,6 @@ dfs_flag = read_parquet_files_from_s3(
         "flag",
     )
 )
-"""
-for i in dfs_flag:
-    print(i)
-
-dfs_flag["2024-01-19_18:46-clever-boni"].sv_outlier_type.value_counts()
-"""
 
 recode_dict = {
     "PTAX-203 flag (Low)": {

--- a/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
+++ b/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
@@ -58,13 +58,11 @@ def process_dataframe(df, recode_dict):
         df.insert(pos, f"sv_outlier_reason{i}", np.nan)
         pos += 1
 
-    print(df.dtypes)
     # Use the dictionary to populate the new columns
     for key, value in recode_dict.items():
         mask = df["sv_outlier_type"] == key
         for col, val in value.items():
             df.loc[mask, col] = val
-    print(df.dtypes)
 
     df = df.drop(columns=["sv_outlier_type"])
 


### PR DESCRIPTION
This PR includes a script that will process our existing flags and output them into our sales val back up bucket. From there we will be able to migrate the new flags into the prod flag s3 bucket. The new flags and the old flags are both backed up in the backup bucket.

We take the existing flag table and replace `sv_outlier_type` with the new set of columns `sv_outlier_reason1`,  `sv_outlier_reason2`,  and `sv_outlier_reason3`.