### PR TITLE
Fix reference to `sv_sale_dup_counts`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,4 +12,3 @@ repos:
     rev: 23.7.0
     hooks:
       - id: black
-        language_version: 3.10.12

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -573,7 +573,7 @@ def get_sale_counts(dups: pd.DataFrame) -> pd.DataFrame:
     """
     v_counts = (
         dups.pin.value_counts()
-        .reset_index(name="count")
+        .reset_index(name="sv_sale_dup_counts")
         .rename(columns={"index": "pin"})
     )
 


### PR DESCRIPTION
This [column ref](https://github.com/ccao-data/model-sales-val/blob/faee8ec26c68f6431d740ce2ea20e04409fc69fe/manual_flagging/yaml/inputs.yaml#L100) was changed in https://github.com/ccao-data/model-sales-val/pull/138, they need to be consistent so I switched it back