### PR TITLE
Add raw price threshold for sales val

### DIFF
--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -807,6 +807,10 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
             "sv_ind_price_low_price_sqft",
         ]
 
+    # Implement raw threshold
+    price_conditions.append(df["sale_price"] > 9_000_000)
+    price_labels.append("sv_raw_price_threshold")
+
     combined_conditions = price_conditions + char_conditions
     combined_labels = price_labels + char_labels
 

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -808,7 +808,7 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
         ]
 
     # Implement raw threshold, unlog  price
-    price_conditions.append((10 ** df["meta_sale_price"]) > 1_000_000)
+    price_conditions.append((10 ** df["meta_sale_price"]) > 15_000_000)
     price_labels.append("sv_ind_raw_price_threshold")
 
     combined_conditions = price_conditions + char_conditions

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -807,9 +807,9 @@ def outlier_type(df: pd.DataFrame, condos: bool) -> pd.DataFrame:
             "sv_ind_price_low_price_sqft",
         ]
 
-    # Implement raw threshold
-    price_conditions.append(df["sale_price"] > 9_000_000)
-    price_labels.append("sv_raw_price_threshold")
+    # Implement raw threshold, unlog  price
+    price_conditions.append((10 ** df["meta_sale_price"]) > 1_000_000)
+    price_labels.append("sv_ind_raw_price_threshold")
 
     combined_conditions = price_conditions + char_conditions
     combined_labels = price_labels + char_labels

--- a/glue/flagging_script_glue/flagging.py
+++ b/glue/flagging_script_glue/flagging.py
@@ -21,7 +21,7 @@ def go(
     iso_forest_cols: list,
     dev_bounds: tuple,
     condos: bool,
-    raw_price_thresh: int,
+    raw_price_threshold: int,
 ):
     """
     This function runs all of our other functions in the correct sequence.
@@ -52,7 +52,7 @@ def go(
     df = iso_forest(df, groups, iso_forest_cols)
     print("iso_forest() done")
     df = outlier_taxonomy(
-        df, dev_bounds, groups, condos=condos, raw_price_thresh=raw_price_thresh
+        df, dev_bounds, groups, condos=condos, raw_price_threshold=raw_price_threshold
     )
     print("outlier_taxonomy() done\nfinished")
 
@@ -73,7 +73,11 @@ def create_group_string(groups: tuple, sep: str) -> str:
 
 
 def outlier_taxonomy(
-    df: pd.DataFrame, permut: tuple, groups: tuple, condos: bool, raw_price_thresh: int
+    df: pd.DataFrame,
+    permut: tuple,
+    groups: tuple,
+    condos: bool,
+    raw_price_threshold: int,
 ):
     """
     Creates columns having to do with our chosen outlier taxonomy.
@@ -89,7 +93,7 @@ def outlier_taxonomy(
 
     df = check_days(df, SHORT_TERM_OWNER_THRESHOLD)
     df = pricing_info(df, permut, groups, condos=condos)
-    df = outlier_type(df, condos=condos, raw_price_thresh=raw_price_thresh)
+    df = outlier_type(df, condos=condos, raw_price_threshold=raw_price_threshold)
 
     return df
 
@@ -745,7 +749,9 @@ def z_normalize_groupby(s: pd.Series):
     return zscore(s, nan_policy="omit")
 
 
-def outlier_type(df: pd.DataFrame, condos: bool, raw_price_thresh: int) -> pd.DataFrame:
+def outlier_type(
+    df: pd.DataFrame, condos: bool, raw_price_threshold: int
+) -> pd.DataFrame:
     """
     This function create indicator columns for each distinct outlier type between price
     and characteristic outliers. These columns are prefixed with 'sv_ind_'.
@@ -813,7 +819,7 @@ def outlier_type(df: pd.DataFrame, condos: bool, raw_price_thresh: int) -> pd.Da
         ]
 
     # Implement raw threshold, unlog  price
-    price_conditions.append((10 ** df["meta_sale_price"]) > raw_price_thresh)
+    price_conditions.append((10 ** df["meta_sale_price"]) > raw_price_threshold)
     price_labels.append("sv_ind_raw_price_threshold")
 
     combined_conditions = price_conditions + char_conditions

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -480,9 +480,9 @@ def get_parameter_df(
     ptax_sd,
     rolling_window,
     time_frame,
-    short_term_thresh,
-    min_group_thresh,
-    raw_price_thresh,
+    short_term_threshold,
+    min_group_threshold,
+    raw_price_threshold,
     run_id,
 ):
     """
@@ -523,9 +523,9 @@ def get_parameter_df(
         "ptax_sd": [ptax_sd],
         "rolling_window": [rolling_window],
         "time_frame": [time_frame],
-        "short_term_owner_threshold": [short_term_thresh],
-        "min_group_thresh": [min_group_thresh],
-        "raw_price_thresh": [raw_price_thresh],
+        "short_term_owner_threshold": [short_term_threshold],
+        "min_group_thresh": [min_group_threshold],
+        "raw_price_threshold": [raw_price_threshold],
     }
 
     df_parameters = pd.DataFrame(parameter_dict_to_df)

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -144,7 +144,8 @@ def classify_outliers(df, stat_groups: list, min_threshold):
     2. Implement our group threshold requirement. In the statistical flagging process, if
     the group a sale belongs too is below N=30 then we want to manually set these flags to
     non-outlier status, even if they were flagged in the mansueto script. This requirement
-    is bypasses for ptax outliers - we don't care about group threshold in this case.
+    is bypasses for ptax outliers and raw price threshold outliers - we don't care about
+    group threshold in this case.
 
     Inputs:
         df: The data right after we perform the flagging script (go()), when the exploded

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -498,9 +498,9 @@ def get_parameter_df(
         ptax_sd: list of standard deviations used for ptax flagging
         rolling_window: how many months used in rolling window methodology
         date_floor: parameter specification that limits earliest flagging write
-        short_term_thresh: short-term threshold for Mansueto's flagging model
+        short_term_threshold: short-term threshold for Mansueto's flagging model
         min_group_thresh: minimum group size threshold needed to flag as outlier
-        raw_price_thresh: raw price threshold at which we unconditionally classify sales as outliers
+        raw_price_threshold: raw price threshold at which we unconditionally classify sales as outliers
         run_id: unique run_id to flagging program run
     Outputs:
         df_parameters: parameters table associated with flagging run

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -482,6 +482,7 @@ def get_parameter_df(
     time_frame,
     short_term_thresh,
     min_group_thresh,
+    raw_price_thresh,
     run_id,
 ):
     """
@@ -499,6 +500,7 @@ def get_parameter_df(
         date_floor: parameter specification that limits earliest flagging write
         short_term_thresh: short-term threshold for Mansueto's flagging model
         min_group_thresh: minimum group size threshold needed to flag as outlier
+        raw_price_thresh: raw price threshold at which we unconditionally classify sales as outliers
         run_id: unique run_id to flagging program run
     Outputs:
         df_parameters: parameters table associated with flagging run
@@ -523,6 +525,7 @@ def get_parameter_df(
         "time_frame": [time_frame],
         "short_term_owner_threshold": [short_term_thresh],
         "min_group_thresh": [min_group_thresh],
+        "raw_price_thresh": [raw_price_thresh],
     }
 
     df_parameters = pd.DataFrame(parameter_dict_to_df)

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -178,6 +178,7 @@ def classify_outliers(df, stat_groups: list, min_threshold):
         "sv_ind_ptax_flag_w_high_price_sqft": "High price per square foot",
         "sv_ind_price_low_price_sqft": "Low price per square foot",
         "sv_ind_ptax_flag_w_low_price_sqft": "Low price per square foot",
+        "sv_raw_price_threshold": "Raw price threshold",
         "sv_ind_ptax_flag": "PTAX-203 Exclusion",
         "sv_ind_char_short_term_owner": "Short-term owner",
         "sv_ind_char_family_sale": "Family Sale",
@@ -199,6 +200,11 @@ def classify_outliers(df, stat_groups: list, min_threshold):
 
     Note: This doesn't apply for sales that also have a ptax outlier status.
           In this case, we still assign the price outlier status.
+
+          We also don't apply this threshold with sv_raw_price_threshold,
+          since this is design to be a safeguard that catches very high price
+          sales that may have slipped through the cracks due to the group
+          threshold requirement
     """
     group_thresh_price_fix = [
         "sv_ind_price_high_price",
@@ -237,12 +243,14 @@ def classify_outliers(df, stat_groups: list, min_threshold):
     # Drop the _merge column
     df = df.drop(columns=["_merge"])
 
-    # Assign outlier status
+    # Assign outlier status, these are the outlier types
+    # that assign a sale as an outlier
     values_to_check = {
         "High price",
         "Low price",
         "High price per square foot",
         "Low price per square foot",
+        "Raw price threshold",
     }
 
     df["sv_is_outlier"] = np.where(

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -203,7 +203,7 @@ def classify_outliers(df, stat_groups: list, min_threshold):
           In this case, we still assign the price outlier status.
 
           We also don't apply this threshold with sv_raw_price_threshold,
-          since this is design to be a safeguard that catches very high price
+          since this is designed to be a safeguard that catches very high price
           sales that may have slipped through the cracks due to the group
           threshold requirement
     """

--- a/glue/sales_val_flagging.py
+++ b/glue/sales_val_flagging.py
@@ -178,7 +178,7 @@ def classify_outliers(df, stat_groups: list, min_threshold):
         "sv_ind_ptax_flag_w_high_price_sqft": "High price per square foot",
         "sv_ind_price_low_price_sqft": "Low price per square foot",
         "sv_ind_ptax_flag_w_low_price_sqft": "Low price per square foot",
-        "sv_raw_price_threshold": "Raw price threshold",
+        "sv_ind_raw_price_threshold": "Raw price threshold",
         "sv_ind_ptax_flag": "PTAX-203 Exclusion",
         "sv_ind_char_short_term_owner": "Short-term owner",
         "sv_ind_char_family_sale": "Family Sale",

--- a/manual_flagging/flagging.py
+++ b/manual_flagging/flagging.py
@@ -300,6 +300,7 @@ for df_name, df_info in dfs_to_flag.items():
         iso_forest_cols=df_info["iso_forest_cols"],
         dev_bounds=tuple(inputs["dev_bounds"]),
         condos=df_info["condos_boolean"],
+        raw_price_threshold=inputs["raw_price_threshold"],
     )
 
     # Add the edited or unedited dataframe to the new dictionary
@@ -400,8 +401,9 @@ df_parameter = flg.get_parameter_df(
     ptax_sd=inputs["ptax_sd"],
     rolling_window=inputs["rolling_window_months"],
     time_frame=inputs["time_frame"],
-    short_term_thresh=flg_model.SHORT_TERM_OWNER_THRESHOLD,
+    short_term_threshold=flg_model.SHORT_TERM_OWNER_THRESHOLD,
     min_group_thresh=inputs["min_groups_threshold"],
+    raw_price_threshold=inputs["raw_price_threshold"],
     run_id=run_id,
 )
 

--- a/manual_flagging/yaml/inputs.yaml
+++ b/manual_flagging/yaml/inputs.yaml
@@ -12,14 +12,14 @@ run_note: |
 # the version number by 1 for existing flags in sales; for sales
 # without flags, it assigns a version number of "1". The latest
 # version of each sale flag can be found in the "default"."vw_pin_sale" view.
-manual_update: true
+manual_update: false
 
 # manual_update_only_new_sales: A boolean that only is in play when
 # manual_update = true. If true, the sales val pipeline will only
 # flag sales that currently have no existing flag in the sale.flag
 # table. In other words, it will flag unseen sales, not sales that
 # the sales val model has already given a flag value to.
-manual_update_only_new_sales: false
+manual_update_only_new_sales: true
 
 # "housing_market_type" and "run_tri" configurations determine the
 # specificity of flagging. First, we retrieve the run tris, then run

--- a/manual_flagging/yaml/inputs.yaml
+++ b/manual_flagging/yaml/inputs.yaml
@@ -166,4 +166,4 @@ min_groups_threshold: 30
 
 # This is the raw price threshold that is used to set sales to outlier status
 # regardless of group size
-raw_price_threshold: 1500000
+raw_price_threshold: 15_000_000

--- a/manual_flagging/yaml/inputs.yaml
+++ b/manual_flagging/yaml/inputs.yaml
@@ -19,7 +19,7 @@ manual_update: false
 # flag sales that currently have no existing flag in the sale.flag
 # table. In other words, it will flag unseen sales, not sales that
 # the sales val model has already given a flag value to.
-manual_update_only_new_sales: true
+manual_update_only_new_sales: false
 
 # "housing_market_type" and "run_tri" configurations determine the
 # specificity of flagging. First, we retrieve the run tris, then run
@@ -30,7 +30,7 @@ housing_market_type: [
   "res_single_family",
   "res_multi_family",
   "res_all",
-  "condos"
+  #"condos"
 ]
 run_tri: [1, 2, 3]
 
@@ -151,7 +151,7 @@ dev_bounds: [2, 2]
 # sale.flag table. Leave 'end' blank if we want to flag all sales
 # since the start date
 time_frame:
-  start: "2014-01-01"
+  start: "2022-01-01"
   end:
 
 # How many total months to include in the grouping methodology
@@ -163,3 +163,7 @@ ptax_sd: [1, 1]
 
 # Flags are only applied if there are at least this many sales in the group
 min_groups_threshold: 30
+
+# This is the raw price threshold that is used to set sales to outlier status
+# regardless of group size
+raw_price_thresh: 15000000

--- a/manual_flagging/yaml/inputs.yaml
+++ b/manual_flagging/yaml/inputs.yaml
@@ -166,4 +166,4 @@ min_groups_threshold: 30
 
 # This is the raw price threshold that is used to set sales to outlier status
 # regardless of group size
-raw_price_thresh: 1500000
+raw_price_threshold: 1500000

--- a/manual_flagging/yaml/inputs.yaml
+++ b/manual_flagging/yaml/inputs.yaml
@@ -12,7 +12,7 @@ run_note: |
 # the version number by 1 for existing flags in sales; for sales
 # without flags, it assigns a version number of "1". The latest
 # version of each sale flag can be found in the "default"."vw_pin_sale" view.
-manual_update: false
+manual_update: true
 
 # manual_update_only_new_sales: A boolean that only is in play when
 # manual_update = true. If true, the sales val pipeline will only
@@ -30,7 +30,7 @@ housing_market_type: [
   "res_single_family",
   "res_multi_family",
   "res_all",
-  #"condos"
+  "condos"
 ]
 run_tri: [1, 2, 3]
 
@@ -151,7 +151,7 @@ dev_bounds: [2, 2]
 # sale.flag table. Leave 'end' blank if we want to flag all sales
 # since the start date
 time_frame:
-  start: "2022-01-01"
+  start: "2014-01-01"
   end:
 
 # How many total months to include in the grouping methodology
@@ -166,4 +166,4 @@ min_groups_threshold: 30
 
 # This is the raw price threshold that is used to set sales to outlier status
 # regardless of group size
-raw_price_thresh: 15000000
+raw_price_thresh: 1500000


### PR DESCRIPTION
In the current methodology, a sale with a price of 10 billion could make it into the model. This is because the statistical groups sales val uses to flag sales automatically include the sales if its group has less than 30 sales. We add a cap that automatically disqualifies sales regardless of the group threshold.

We also standardize instances of "thresh" naming to "threshold"