### PR TITLE
Fix keyword arg

### DIFF
--- a/manual_flagging/flagging.py
+++ b/manual_flagging/flagging.py
@@ -402,7 +402,7 @@ df_parameter = flg.get_parameter_df(
     rolling_window=inputs["rolling_window_months"],
     time_frame=inputs["time_frame"],
     short_term_threshold=flg_model.SHORT_TERM_OWNER_THRESHOLD,
-    min_group_thresh=inputs["min_groups_threshold"],
+    min_group_threshold=inputs["min_groups_threshold"],
     raw_price_threshold=inputs["raw_price_threshold"],
     run_id=run_id,
 )


### PR DESCRIPTION
We forgot to update a keyword arg when [we did some standardizing of naming](https://github.com/ccao-data/model-sales-val/commit/962ef1da010b9599a43755bf19bfd690c75b16c5).