### PR TITLE
Add ruff to pre-commit config and reformat code to follow its styleguide

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,13 @@ repos:
     rev: v0.0.18
     hooks:
       - id: shellcheck
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.0
     hooks:
-      - id: black
+      # Python linter. Ruff recommends running this before the formatter to
+      # avoid conflicts when using the --fix flag
+      - id: ruff
+        args:
+          - --fix
+      # Formatter
+      - id: ruff-format

--- a/migrations/0001_update_metadata_structure_after_2023_flag_update.py
+++ b/migrations/0001_update_metadata_structure_after_2023_flag_update.py
@@ -1,9 +1,9 @@
 import os
+import subprocess as sp
+
 import awswrangler as wr
 import pandas as pd
-import numpy as np
 from glue import sales_val_flagging as flg
-import subprocess as sp
 
 """
 Migration to update the structure of the prod metadata following 2023 reassessment prod flag updates.
@@ -143,8 +143,8 @@ dfs_sale_parameter["2024-01-19_18:46-clever-boni"]["iso_forest_cols"] = str(
 # Although this structure didn't exist when we ran the sales val program
 # it still can fit into the new structure (all tris/market types
 #  were ran with og_mansueto)
-dfs_sale_parameter["2024-01-19_18:46-clever-boni"]["sales_to_write_filter"] = str(
-    {"column": None, "values": None}
+dfs_sale_parameter["2024-01-19_18:46-clever-boni"]["sales_to_write_filter"] = (
+    str({"column": None, "values": None})
 )
 
 dfs_sale_parameter["2024-01-19_18:46-clever-boni"]["run_filter"] = str(
@@ -159,7 +159,9 @@ dfs_sale_parameter["2024-01-19_18:46-clever-boni"]["run_filter"] = str(
 
 # This run updated all condos and res, I believe leaving this column as null would be sufficient
 # since we didn't have the existing structure when this run happened.
-dfs_sale_parameter["2024-01-19_18:46-clever-boni"]["housing_market_class_codes"] = ""
+dfs_sale_parameter["2024-01-19_18:46-clever-boni"][
+    "housing_market_class_codes"
+] = ""
 
 dfs_sale_parameter["2024-01-19_18:46-clever-boni"] = dfs_sale_parameter[
     "2024-01-19_18:46-clever-boni"
@@ -184,7 +186,9 @@ dfs_sale_parameter["2024-01-19_18:46-clever-boni"] = dfs_sale_parameter[
 
 # Add/Adjust condos city tri updates:
 dfs_sale_parameter["2024-02-01_12:24-nifty-tayun"] = pd.read_parquet(
-    os.path.join(root, "manual_flagging/new_condo_metadata/df_parameters.parquet")
+    os.path.join(
+        root, "manual_flagging/new_condo_metadata/df_parameters.parquet"
+    )
 )
 
 dfs_sale_parameter["2024-02-01_12:24-nifty-tayun"]["stat_groups"] = str(
@@ -208,8 +212,8 @@ dfs_sale_parameter["2024-02-01_12:24-nifty-tayun"]["time_frame"] = str(
     {"start": "2014-01-01", "end": None}
 )
 
-dfs_sale_parameter["2024-02-01_12:24-nifty-tayun"]["sales_to_write_filter"] = str(
-    {"column": None, "values": None}
+dfs_sale_parameter["2024-02-01_12:24-nifty-tayun"]["sales_to_write_filter"] = (
+    str({"column": None, "values": None})
 )
 
 dfs_sale_parameter["2024-02-01_12:24-nifty-tayun"]["run_filter"] = str(
@@ -217,7 +221,9 @@ dfs_sale_parameter["2024-02-01_12:24-nifty-tayun"]["run_filter"] = str(
 )
 
 # Class code structure in yaml wasn't present in this run
-dfs_sale_parameter["2024-02-01_12:24-nifty-tayun"]["housing_market_class_codes"] = ""
+dfs_sale_parameter["2024-02-01_12:24-nifty-tayun"][
+    "housing_market_class_codes"
+] = ""
 
 dfs_sale_parameter["2024-02-01_12:24-nifty-tayun"] = dfs_sale_parameter[
     "2024-02-01_12:24-nifty-tayun"
@@ -242,7 +248,9 @@ dfs_sale_parameter["2024-02-01_12:24-nifty-tayun"] = dfs_sale_parameter[
 
 # Add/Adjust res city tri updates:
 dfs_sale_parameter["2024-01-29_14:40-pensive-rina"] = pd.read_parquet(
-    os.path.join(root, "manual_flagging/new_res_metadata/df_parameters.parquet")
+    os.path.join(
+        root, "manual_flagging/new_res_metadata/df_parameters.parquet"
+    )
 )
 
 dfs_sale_parameter["2024-01-29_14:40-pensive-rina"]["stat_groups"] = str(
@@ -287,16 +295,21 @@ dfs_sale_parameter["2024-01-29_14:40-pensive-rina"]["time_frame"] = str(
     {"start": "2014-01-01", "end": None}
 )
 
-dfs_sale_parameter["2024-01-29_14:40-pensive-rina"]["sales_to_write_filter"] = str(
-    {"column": None, "values": None}
-)
+dfs_sale_parameter["2024-01-29_14:40-pensive-rina"][
+    "sales_to_write_filter"
+] = str({"column": None, "values": None})
 
 dfs_sale_parameter["2024-01-29_14:40-pensive-rina"]["run_filter"] = str(
-    {"housing_market_type": ["res_single_family", "res_multi_family"], "run_tri": [1]}
+    {
+        "housing_market_type": ["res_single_family", "res_multi_family"],
+        "run_tri": [1],
+    }
 )
 
 # Class code structure in yaml wasn't present in this run
-dfs_sale_parameter["2024-01-29_14:40-pensive-rina"]["housing_market_class_codes"] = ""
+dfs_sale_parameter["2024-01-29_14:40-pensive-rina"][
+    "housing_market_class_codes"
+] = ""
 
 dfs_sale_parameter["2024-01-29_14:40-pensive-rina"] = dfs_sale_parameter[
     "2024-01-29_14:40-pensive-rina"
@@ -335,30 +348,34 @@ dfs_sale_group_mean = read_parquets_to_dfs("group_mean")
 
 # Add/Adjust condos city tri updates:
 dfs_sale_group_mean["2024-02-01_12:24-nifty-tayun"] = pd.read_parquet(
-    os.path.join(root, "manual_flagging/new_condo_metadata/df_condo_group_mean.parquet")
+    os.path.join(
+        root, "manual_flagging/new_condo_metadata/df_condo_group_mean.parquet"
+    )
 )
 # Add/Adjust res city tri updates:
 dfs_sale_group_mean["2024-01-29_14:40-pensive-rina"] = pd.read_parquet(
-    os.path.join(root, "manual_flagging/new_res_metadata/df_group_mean.parquet")
+    os.path.join(
+        root, "manual_flagging/new_res_metadata/df_group_mean.parquet"
+    )
 )
 
 # OG initial run
 # 'res_og_mansueto', 'condos_og_mansueto'
-dfs_sale_group_mean["2024-01-19_18:46-clever-boni"]["group"] = dfs_sale_group_mean[
-    "2024-01-19_18:46-clever-boni"
-]["group"].apply(
-    lambda value: value + "-res_all"
-    if value.count("_") == 2
-    else (value + "-condos" if value.count("_") == 1 else value)
+dfs_sale_group_mean["2024-01-19_18:46-clever-boni"]["group"] = (
+    dfs_sale_group_mean["2024-01-19_18:46-clever-boni"]["group"].apply(
+        lambda value: value + "-res_all"
+        if value.count("_") == 2
+        else (value + "-condos" if value.count("_") == 1 else value)
+    )
 )
 
 # Update res run
-dfs_sale_group_mean["2024-01-29_14:40-pensive-rina"]["group"] = dfs_sale_group_mean[
-    "2024-01-29_14:40-pensive-rina"
-]["group"].apply(
-    lambda value: value + "-res_single_family"
-    if "40_years" in value
-    else (value + "-res_multi_family" if "20_years" in value else value)
+dfs_sale_group_mean["2024-01-29_14:40-pensive-rina"]["group"] = (
+    dfs_sale_group_mean["2024-01-29_14:40-pensive-rina"]["group"].apply(
+        lambda value: value + "-res_single_family"
+        if "40_years" in value
+        else (value + "-res_multi_family" if "20_years" in value else value)
+    )
 )
 
 # Update new condos run
@@ -377,7 +394,9 @@ dfs_sale_metadata = read_parquets_to_dfs("metadata")
 
 # Add/Adjust condos city tri updates:
 dfs_sale_metadata["2024-02-01_12:24-nifty-tayun"] = pd.read_parquet(
-    os.path.join(root, "manual_flagging/new_condo_metadata/df_metadata.parquet")
+    os.path.join(
+        root, "manual_flagging/new_condo_metadata/df_metadata.parquet"
+    )
 )
 # Add/Adjust res city tri updates:
 dfs_sale_metadata["2024-01-29_14:40-pensive-rina"] = pd.read_parquet(

--- a/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
+++ b/migrations/0002_update_outlier_column_structure_w_iasworld_2024_update.py
@@ -1,10 +1,9 @@
-import awswrangler as wr
-import boto3
 import os
 import subprocess as sp
+
+import awswrangler as wr
+import boto3
 import numpy as np
-from pyathena import connect
-from pyathena.pandas.util import as_pandas
 
 # Set working dir to manual_update, standardize yaml and src locations
 root = sp.getoutput("git rev-parse --show-toplevel")
@@ -77,7 +76,10 @@ def write_dfs_to_s3(dfs, bucket, table):
     for df_name, df in dfs.items():
         file_path = f"{bucket}/0002_update_outlier_column_structure_w_iasworld_2024_update/new_prod_data/{table}/{df_name}.parquet"
         wr.s3.to_parquet(
-            df=df, path=file_path, index=False, dtype={"sv_outlier_reason3": "string"}
+            df=df,
+            path=file_path,
+            index=False,
+            dtype={"sv_outlier_reason3": "string"},
         )
 
 

--- a/migrations/0003_fix_is_ptax_outlier_col.py
+++ b/migrations/0003_fix_is_ptax_outlier_col.py
@@ -3,11 +3,8 @@
 # of the sales val pipeline accidentally used the wrong reason codes to
 # compute this column, resulting in every row getting set to False
 import os
+
 import awswrangler as wr
-import pandas as pd
-import numpy as np
-from glue import sales_val_flagging as flg
-import subprocess as sp
 
 
 def read_parquets_to_dfs(table):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "model-sales-val"
+version = "0.0.1"
+readme = "README.md"
+
+[tool.ruff]
+line-length = 79
+
+[tool.ruff.lint]
+# Add isort to ruff linting
+extend-select = ["I"]

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -10,7 +10,6 @@ import logging
 import os
 import sys
 
-import pandas
 import pyathena
 import pyathena.pandas.util
 
@@ -111,12 +110,20 @@ if __name__ == "__main__":
     # Run some data integrity checks
     not_null_fields = [PIN_FIELD, SALE_KEY_FIELD, RUN_ID_FIELD]
     for field in not_null_fields:
-        assert flag_df[flag_df[field].isnull()].empty, f"{field} contains nulls"
+        assert flag_df[flag_df[field].isnull()].empty, (
+            f"{field} contains nulls"
+        )
 
     logger.info(f"Got {num_flags} sales with flags")
 
-    for field in [OUTLIER_REASON1_FIELD, OUTLIER_REASON2_FIELD, OUTLIER_REASON3_FIELD]:
-        invalid_values = flag_df[~flag_df[field].isin(OUTLIER_TYPE_CODES.values())]
+    for field in [
+        OUTLIER_REASON1_FIELD,
+        OUTLIER_REASON2_FIELD,
+        OUTLIER_REASON3_FIELD,
+    ]:
+        invalid_values = flag_df[
+            ~flag_df[field].isin(OUTLIER_TYPE_CODES.values())
+        ]
         assert invalid_values.empty, f"{field} contains invalid codes"
 
     # Tests confirming that a price outlier reason is needed
@@ -130,9 +137,9 @@ if __name__ == "__main__":
     ]
 
     for price_code in PRICE_CODES:
-        assert (
-            price_code in OUTLIER_TYPE_CODES
-        ), f"{price_code} is in PRICE_CODES but missing from OUTLIER_TYPE_CODES"
+        assert price_code in OUTLIER_TYPE_CODES, (
+            f"{price_code} is in PRICE_CODES but missing from OUTLIER_TYPE_CODES"
+        )
 
     PRICE_CODES = [OUTLIER_TYPE_CODES[code] for code in PRICE_CODES]
 
@@ -145,17 +152,17 @@ if __name__ == "__main__":
     mask_all_not = ~flag_df[columns_to_check].isin(PRICE_CODES).any(axis=1)
     mask_any = flag_df[columns_to_check].isin(PRICE_CODES).any(axis=1)
 
-    assert (flag_df[IS_OUTLIER_FIELD] == "N").equals(
-        mask_all_not
-    ), "If there is a price reason in one of the outlier reason fields, it should be classified as an outlier"
+    assert (flag_df[IS_OUTLIER_FIELD] == "N").equals(mask_all_not), (
+        "If there is a price reason in one of the outlier reason fields, it should be classified as an outlier"
+    )
 
-    assert (flag_df[IS_OUTLIER_FIELD] == "Y").equals(
-        mask_any
-    ), "If there is no price reason in any of the outlier reason fields, it should not be an outlier"
+    assert (flag_df[IS_OUTLIER_FIELD] == "Y").equals(mask_any), (
+        "If there is no price reason in any of the outlier reason fields, it should not be an outlier"
+    )
 
-    assert (
-        num_flags == expected_num_flags
-    ), f"Expected {expected_num_flags} total sales, got {num_flags}"
+    assert num_flags == expected_num_flags, (
+        f"Expected {expected_num_flags} total sales, got {num_flags}"
+    )
 
     logger.info("Writing CSV to stdout")
 

--- a/src/model.py
+++ b/src/model.py
@@ -4,13 +4,13 @@ non-arms length transaction detection using statistical and heuristic methods.
 """
 
 import re
+
 import numpy as np
 import pandas as pd
-
 from scipy.stats import zscore
+from sklearn.decomposition import PCA
 from sklearn.ensemble import IsolationForest
 from sklearn.preprocessing import LabelEncoder
-from sklearn.decomposition import PCA
 
 SHORT_TERM_OWNER_THRESHOLD = 365  # 365 = 365 days or 1 year
 
@@ -45,14 +45,19 @@ def go(
         print("Flagging for residential")
 
     print("Initialize")
-    df = create_stats(df, groups, condos=condos)  # 'year', 'township_code', 'class'
+    # 'year', 'township_code', 'class'
+    df = create_stats(df, groups, condos=condos)
     print("create_stats() done")
     df = string_processing(df)
     print("string_processing() done")
     df = iso_forest(df, groups, iso_forest_cols)
     print("iso_forest() done")
     df = outlier_taxonomy(
-        df, dev_bounds, groups, condos=condos, raw_price_threshold=raw_price_threshold
+        df,
+        dev_bounds,
+        groups,
+        condos=condos,
+        raw_price_threshold=raw_price_threshold,
     )
     print("outlier_taxonomy() done\nfinished")
 
@@ -93,7 +98,9 @@ def outlier_taxonomy(
 
     df = check_days(df, SHORT_TERM_OWNER_THRESHOLD)
     df = pricing_info(df, permut, groups, condos=condos)
-    df = outlier_type(df, condos=condos, raw_price_threshold=raw_price_threshold)
+    df = outlier_type(
+        df, condos=condos, raw_price_threshold=raw_price_threshold
+    )
 
     return df
 
@@ -267,10 +274,14 @@ def pricing_info(
     )["sv_cgdr"].apply(z_normalize_groupby)
 
     holds = get_thresh(df, prices, permut, groups)
-    df["sv_pricing"] = df.apply(price_column, args=(holds, groups, condos), axis=1)
+    df["sv_pricing"] = df.apply(
+        price_column, args=(holds, groups, condos), axis=1
+    )
 
     if not condos:
-        df["sv_which_price"] = df.apply(which_price, args=(holds, groups), axis=1)
+        df["sv_which_price"] = df.apply(
+            which_price, args=(holds, groups), axis=1
+        )
 
     return df
 
@@ -288,12 +299,14 @@ def which_price(row: pd.Series, thresholds: dict, groups: tuple) -> str:
     group_string = create_group_string(groups, "_")
     key = tuple(row[group] for group in groups)
 
-    if thresholds.get(f"sv_price_deviation_{group_string}").get(key) and thresholds.get(
-        f"sv_price_per_sqft_deviation_{group_string}"
-    ).get(key):
-        s_std, *s_std_range = thresholds.get(f"sv_price_deviation_{group_string}").get(
-            key
-        )
+    if thresholds.get(f"sv_price_deviation_{group_string}").get(
+        key
+    ) and thresholds.get(f"sv_price_per_sqft_deviation_{group_string}").get(
+        key
+    ):
+        s_std, *s_std_range = thresholds.get(
+            f"sv_price_deviation_{group_string}"
+        ).get(key)
         s_lower, s_upper = s_std_range
         sq_std, *sq_std_range = thresholds.get(
             f"sv_price_per_sqft_deviation_{group_string}"
@@ -302,30 +315,40 @@ def which_price(row: pd.Series, thresholds: dict, groups: tuple) -> str:
         if not between_two_numbers(
             row[f"sv_price_deviation_{group_string}"], s_lower, s_upper
         ) and between_two_numbers(
-            row[f"sv_price_per_sqft_deviation_{group_string}"], sq_lower, sq_upper
+            row[f"sv_price_per_sqft_deviation_{group_string}"],
+            sq_lower,
+            sq_upper,
         ):
             value = "(raw)"
         elif between_two_numbers(
             row[f"sv_price_deviation_{group_string}"], s_lower, s_upper
         ) and not between_two_numbers(
-            row[f"sv_price_per_sqft_deviation_{group_string}"], sq_lower, sq_upper
+            row[f"sv_price_per_sqft_deviation_{group_string}"],
+            sq_lower,
+            sq_upper,
         ):
             value = "(sqft)"
         elif not between_two_numbers(
             row[f"sv_price_deviation_{group_string}"], s_lower, s_upper
         ) and not between_two_numbers(
-            row[f"sv_price_per_sqft_deviation_{group_string}"], sq_lower, sq_upper
+            row[f"sv_price_per_sqft_deviation_{group_string}"],
+            sq_lower,
+            sq_upper,
         ):
             value = "(raw & sqft)"
 
     return value
 
 
-def between_two_numbers(num: int or float, a: int or float, b: int or float) -> bool:
+def between_two_numbers(
+    num: int or float, a: int or float, b: int or float
+) -> bool:
     return a < num < b
 
 
-def price_column(row: pd.Series, thresholds: dict, groups: tuple, condos: bool) -> str:
+def price_column(
+    row: pd.Series, thresholds: dict, groups: tuple, condos: bool
+) -> str:
     """
     Determines whether the record is a high price outlier or a low price outlier.
     If the record is also a price change outlier, than add 'swing' to the string.
@@ -341,7 +364,7 @@ def price_column(row: pd.Series, thresholds: dict, groups: tuple, condos: bool) 
     group_string = create_group_string(groups, "_")
     key = tuple(row[group] for group in groups)
 
-    if condos == True:
+    if condos:
         if thresholds.get(f"sv_price_deviation_{group_string}").get(key):
             s_std, *s_std_range = thresholds.get(
                 f"sv_price_deviation_{group_string}"
@@ -358,7 +381,9 @@ def price_column(row: pd.Series, thresholds: dict, groups: tuple, condos: bool) 
             if (
                 price
                 and pd.notnull(row[f"sv_cgdr_deviation_{group_string}"])
-                and thresholds.get(f"sv_cgdr_deviation_{group_string}").get(key)
+                and thresholds.get(f"sv_cgdr_deviation_{group_string}").get(
+                    key
+                )
             ):
                 # not every combo will have pct change info so we need this check
                 p_std, *p_std_range = thresholds.get(
@@ -376,7 +401,9 @@ def price_column(row: pd.Series, thresholds: dict, groups: tuple, condos: bool) 
     else:
         if thresholds.get(f"sv_price_deviation_{group_string}").get(
             key
-        ) and thresholds.get(f"sv_price_per_sqft_deviation_{group_string}").get(key):
+        ) and thresholds.get(
+            f"sv_price_per_sqft_deviation_{group_string}"
+        ).get(key):
             s_std, *s_std_range = thresholds.get(
                 f"sv_price_deviation_{group_string}"
             ).get(key)
@@ -389,13 +416,15 @@ def price_column(row: pd.Series, thresholds: dict, groups: tuple, condos: bool) 
 
             if (
                 row[f"sv_price_deviation_{group_string}"] > s_upper
-                or row[f"sv_price_per_sqft_deviation_{group_string}"] > sq_upper
+                or row[f"sv_price_per_sqft_deviation_{group_string}"]
+                > sq_upper
             ):
                 value = "High price"
                 price = True
             elif (
                 row[f"sv_price_deviation_{group_string}"] < s_lower
-                or row[f"sv_price_per_sqft_deviation_{group_string}"] < sq_lower
+                or row[f"sv_price_per_sqft_deviation_{group_string}"]
+                < sq_lower
             ):
                 value = "Low price"
                 price = True
@@ -403,7 +432,9 @@ def price_column(row: pd.Series, thresholds: dict, groups: tuple, condos: bool) 
             if (
                 price
                 and pd.notnull(row[f"sv_cgdr_deviation_{group_string}"])
-                and thresholds.get(f"sv_cgdr_deviation_{group_string}").get(key)
+                and thresholds.get(f"sv_cgdr_deviation_{group_string}").get(
+                    key
+                )
             ):
                 # not every combo will have pct change info so we need this check
                 p_std, *p_std_range = thresholds.get(
@@ -421,7 +452,9 @@ def price_column(row: pd.Series, thresholds: dict, groups: tuple, condos: bool) 
     return value
 
 
-def create_stats(df: pd.DataFrame, groups: tuple, condos: bool) -> pd.DataFrame:
+def create_stats(
+    df: pd.DataFrame, groups: tuple, condos: bool
+) -> pd.DataFrame:
     """
     Create all statistical outlier measures.
     Inputs:
@@ -465,7 +498,7 @@ def percent_change(df: pd.DataFrame) -> pd.DataFrame:
         df (pd.DataFrame): dataframe with CGR statistic and previous_price column
     """
 
-    original_df = df[df["original_observation"] == True].copy()
+    original_df = df[df["original_observation"] is True].copy()
     original_df["sv_previous_price"] = (
         original_df.sort_values("meta_sale_date")
         .groupby(["pin"])["meta_sale_price"]
@@ -545,7 +578,9 @@ def deviation_dollars(df: pd.DataFrame, groups: tuple) -> pd.DataFrame:
     return df
 
 
-def grouping_mean(df: pd.DataFrame, groups: tuple, condos: bool) -> pd.DataFrame:
+def grouping_mean(
+    df: pd.DataFrame, groups: tuple, condos: bool
+) -> pd.DataFrame:
     """
     Gets sale_price mean by two groupings. Usually town + class.
     Helper for create_stats().
@@ -559,7 +594,7 @@ def grouping_mean(df: pd.DataFrame, groups: tuple, condos: bool) -> pd.DataFrame
 
     group_mean = df.groupby(list(groups))["meta_sale_price"].mean()
 
-    if condos == True:
+    if condos:
         df.set_index(list(groups), inplace=True)
         df[f"sv_mean_price_{group_string}"] = group_mean
     else:
@@ -614,7 +649,9 @@ def get_movement(dups: pd.DataFrame, groups: tuple) -> pd.DataFrame:
         .shift()
     )
     dups["sv_price_movement"] = (
-        dups[f"sv_deviation_{group_string}_mean_price_abs"].lt(temp).astype(float)
+        dups[f"sv_deviation_{group_string}_mean_price_abs"]
+        .lt(temp)
+        .astype(float)
     )
     dups["sv_price_movement"] = np.select(
         [(dups["sv_price_movement"] == 0), (dups["sv_price_movement"] == 1)],
@@ -636,7 +673,7 @@ def transaction_days(df: pd.DataFrame) -> pd.DataFrame:
         df (pd.DataFrame): DataFrame with new column
     """
 
-    original_df = df[df["original_observation"] == True].copy()
+    original_df = df[df["original_observation"] is True].copy()
     original_df["sv_days_since_last_transaction"] = (
         original_df.sort_values("meta_sale_date")
         .groupby("pin")["meta_sale_date"]
@@ -675,7 +712,9 @@ def check_days(df: pd.DataFrame, threshold: int) -> pd.DataFrame:
     return df
 
 
-def get_thresh(df: pd.DataFrame, cols: list, permut: tuple, groups: tuple) -> dict:
+def get_thresh(
+    df: pd.DataFrame, cols: list, permut: tuple, groups: tuple
+) -> dict:
     """
     Creates a nested dictionary where the top level key is a column
     and the 2nd-level key is a (township, class) combo.
@@ -701,7 +740,9 @@ def get_thresh(df: pd.DataFrame, cols: list, permut: tuple, groups: tuple) -> di
 
     for col in cols:
         df[col] = df[col].astype(float)
-        grouped = df.dropna(subset=list(groups) + [col]).groupby(list(groups))[col]
+        grouped = df.dropna(subset=list(groups) + [col]).groupby(list(groups))[
+            col
+        ]
         lower_limit = grouped.mean() - (grouped.std(ddof=0) * permut[0])
         upper_limit = grouped.mean() + (grouped.std(ddof=0) * permut[1])
         std = grouped.std(ddof=0)
@@ -765,7 +806,9 @@ def outlier_type(
     char_conditions = [
         df["sv_short_owner"] == "Short-term owner",
         df["sv_name_match"] != "No match",
-        df[["sv_buyer_category", "sv_seller_category"]].eq("legal_entity").any(axis=1),
+        df[["sv_buyer_category", "sv_seller_category"]]
+        .eq("legal_entity")
+        .any(axis=1),
         df["sv_anomaly"] == "Outlier",
         df["sv_pricing"].str.contains("High price swing")
         | df["sv_pricing"].str.contains("Low price swing"),
@@ -819,7 +862,9 @@ def outlier_type(
         ]
 
     # Implement raw threshold, unlog  price
-    price_conditions.append((10 ** df["meta_sale_price"]) > raw_price_threshold)
+    price_conditions.append(
+        (10 ** df["meta_sale_price"]) > raw_price_threshold
+    )
     price_labels.append("sv_ind_raw_price_threshold")
 
     combined_conditions = price_conditions + char_conditions
@@ -945,14 +990,17 @@ def get_id(row: pd.Series, col: str) -> str:
         id = "Empty Name"
         return id
 
-    if any(x in words for x in ["vt investment corpor", "v t investment corp"]):
+    if any(
+        x in words for x in ["vt investment corpor", "v t investment corp"]
+    ):
         return "vt investment corporation"
 
     if any(x in words for x in ["national residential nomi"]):
         return "national residential nominee services"
 
     if any(
-        x in words for x in ["first integrity group inc", "first integrity group in"]
+        x in words
+        for x in ["first integrity group inc", "first integrity group in"]
     ):
         return "first integrity group inc"
 
@@ -960,7 +1008,8 @@ def get_id(row: pd.Series, col: str) -> str:
         return "deutsche bank national trust company"
 
     if any(
-        x in words for x in ["cirrus investment group l", "cirrus investment group"]
+        x in words
+        for x in ["cirrus investment group l", "cirrus investment group"]
     ):
         return "cirrus investment group"
 
@@ -986,7 +1035,10 @@ def get_id(row: pd.Series, col: str) -> str:
     ):
         return "the judicial sales corporation"
 
-    if any(x in words for x in ["jpmorgan chase bank n a", "jpmorgan chase bank nati"]):
+    if any(
+        x in words
+        for x in ["jpmorgan chase bank n a", "jpmorgan chase bank nati"]
+    ):
         return "jp morgan chase bank"
 
     if any(
@@ -1002,17 +1054,27 @@ def get_id(row: pd.Series, col: str) -> str:
         return "wells fargo bank national"
 
     if any(
-        x in words for x in ["bayview loan servicing l", "bayview loan servicing ll"]
+        x in words
+        for x in ["bayview loan servicing l", "bayview loan servicing ll"]
     ):
         return "bayview loan servicing llc"
 
-    if any(x in words for x in ["thr property illinois l", "thr property illinois lp"]):
+    if any(
+        x in words
+        for x in ["thr property illinois l", "thr property illinois lp"]
+    ):
         return "thr property illinois lp"
 
-    if any(x in words for x in ["ih3 property illinois lp", "ih3 property illinois l"]):
+    if any(
+        x in words
+        for x in ["ih3 property illinois lp", "ih3 property illinois l"]
+    ):
         return "ih3 property illinois lp"
 
-    if any(x in words for x in ["ih2 property illinois lp", "ih2 property illinois l"]):
+    if any(
+        x in words
+        for x in ["ih2 property illinois lp", "ih2 property illinois l"]
+    ):
         return "ih2 property illinois lp"
 
     if any(
@@ -1026,7 +1088,8 @@ def get_id(row: pd.Series, col: str) -> str:
         return "secretary of housing and urban development"
 
     if any(
-        x in words for x in ["secretary of veterans aff", "the secretary of veterans"]
+        x in words
+        for x in ["secretary of veterans aff", "the secretary of veterans"]
     ):
         return "secretary of veterans affairs"
 
@@ -1229,7 +1292,9 @@ def clean_id(row: pd.Series, col: str) -> str:
     column = col + "_id"
     words = row[column]
 
-    words = re.sub(r" as successor trustee|\b as successor\b| as trustee", "", words)
+    words = re.sub(
+        r" as successor trustee|\b as successor\b| as trustee", "", words
+    )
     words = re.sub(" as$| as $|as $", "", words)
 
     if not (
@@ -1314,11 +1379,17 @@ def string_processing(df: pd.DataFrame) -> pd.DataFrame:
 
     df["sv_buyer_id"] = df.apply(get_id, args=("meta_sale_buyer",), axis=1)
     df["sv_seller_id"] = df.apply(get_id, args=("meta_sale_seller",), axis=1)
-    df["sv_buyer_category"] = df.apply(get_category, args=("sv_buyer",), axis=1)
-    df["sv_seller_category"] = df.apply(get_category, args=("sv_seller",), axis=1)
+    df["sv_buyer_category"] = df.apply(
+        get_category, args=("sv_buyer",), axis=1
+    )
+    df["sv_seller_category"] = df.apply(
+        get_category, args=("sv_seller",), axis=1
+    )
     df["sv_buyer_id"] = df.apply(clean_id, args=("sv_buyer",), axis=1)
     df["sv_seller_id"] = df.apply(clean_id, args=("sv_seller",), axis=1)
-    df["sv_transaction_type"] = df["sv_buyer_category"] + "-" + df["sv_seller_category"]
+    df["sv_transaction_type"] = (
+        df["sv_buyer_category"] + "-" + df["sv_seller_category"]
+    )
 
     df = create_judicial_flag(df)
     df["sv_name_match"] = df.apply(create_name_match, axis=1)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,8 @@
-import awswrangler as wr
 import datetime
-import numpy as np
 import os
+
+import awswrangler as wr
+import numpy as np
 import pandas as pd
 import pytz
 from dateutil.relativedelta import relativedelta
@@ -22,9 +23,9 @@ def months_back(date_str, num_months):
             that is num_months months back from date_str
     """
     # Parse the date string to a datetime object and subtract the months
-    result_date = datetime.datetime.strptime(date_str, "%Y-%m-%d") - relativedelta(
-        months=num_months
-    )
+    result_date = datetime.datetime.strptime(
+        date_str, "%Y-%m-%d"
+    ) - relativedelta(months=num_months)
 
     # Set the day to 1
     result_date = result_date.replace(day=1)
@@ -63,7 +64,9 @@ def add_rolling_window(df, num_months):
             & (df["meta_sale_date"].dt.year == df["rolling_window"].dt.year)
         )
         # Simplify to month level
-        .assign(rolling_window=lambda df: df["rolling_window"].dt.to_period("M"))
+        .assign(
+            rolling_window=lambda df: df["rolling_window"].dt.to_period("M")
+        )
         # Filter such that rolling_window isn't extrapolated into future, we are concerned with historic and present-month data
         .loc[lambda df: df["rolling_window"] <= max_date.to_period("M")]
         # Back to float for flagging script
@@ -98,28 +101,28 @@ def ptax_adjustment(df, groups, ptax_sd, condos: bool):
 
     if not condos:
         df["sv_ind_ptax_flag_w_high_price"] = df["ptax_flag_original"] & (
-            (df[f"sv_price_deviation_{group_string}"] >= ptax_sd[1])
+            df[f"sv_price_deviation_{group_string}"] >= ptax_sd[1]
         )
 
         df["sv_ind_ptax_flag_w_high_price_sqft"] = df["ptax_flag_original"] & (
-            (df[f"sv_price_per_sqft_deviation_{group_string}"] >= ptax_sd[1])
+            df[f"sv_price_per_sqft_deviation_{group_string}"] >= ptax_sd[1]
         )
 
         df["sv_ind_ptax_flag_w_low_price"] = df["ptax_flag_original"] & (
-            (df[f"sv_price_per_sqft_deviation_{group_string}"] <= -ptax_sd[0])
+            df[f"sv_price_per_sqft_deviation_{group_string}"] <= -ptax_sd[0]
         )
 
         df["sv_ind_ptax_flag_w_low_price_sqft"] = df["ptax_flag_original"] & (
-            (df[f"sv_price_per_sqft_deviation_{group_string}"] <= -ptax_sd[0])
+            df[f"sv_price_per_sqft_deviation_{group_string}"] <= -ptax_sd[0]
         )
 
     else:
         df["sv_ind_ptax_flag_w_high_price"] = df["ptax_flag_original"] & (
-            (df[f"sv_price_deviation_{group_string}"] >= ptax_sd[1])
+            df[f"sv_price_deviation_{group_string}"] >= ptax_sd[1]
         )
 
         df["sv_ind_ptax_flag_w_low_price"] = df["ptax_flag_original"] & (
-            (df[f"sv_price_deviation_{group_string}"] <= -ptax_sd[0])
+            df[f"sv_price_deviation_{group_string}"] <= -ptax_sd[0]
         )
 
     df["sv_ind_ptax_flag"] = df["ptax_flag_original"].astype(int)
@@ -158,7 +161,11 @@ def classify_outliers(df, stat_groups: list, min_threshold):
 
     # Merge df_flagged with filtered_groups on the columns to get the matching rows
     df = pd.merge(
-        df, filtered_groups[stat_groups], on=stat_groups, how="left", indicator=True
+        df,
+        filtered_groups[stat_groups],
+        on=stat_groups,
+        how="left",
+        indicator=True,
     )
 
     # Assign sv_outlier_reasons
@@ -224,11 +231,16 @@ def classify_outliers(df, stat_groups: list, min_threshold):
                 # is not met, but only price indicators (`group_thresh_price_fix`) should use this threshold,
                 # since ptax indicators don't currently utilize group threshold logic
                 and not (
-                    row["_merge"] == "both" and reason_ind_col in group_thresh_price_fix
+                    row["_merge"] == "both"
+                    and reason_ind_col in group_thresh_price_fix
                 )
             ):
-                row[f"sv_outlier_reason{len(reasons_added) + 1}"] = current_reason
-                reasons_added.add(current_reason)  # Add current reason to the set
+                row[f"sv_outlier_reason{len(reasons_added) + 1}"] = (
+                    current_reason
+                )
+                reasons_added.add(
+                    current_reason  # Add current reason to the set
+                )
                 if len(reasons_added) >= 3:
                     break
 
@@ -264,10 +276,10 @@ def classify_outliers(df, stat_groups: list, min_threshold):
 
     df = df.assign(
         # PTAX-203 binary
-        sv_is_ptax_outlier=lambda df: (df["sv_is_outlier"] == True)
+        sv_is_ptax_outlier=lambda df: (df["sv_is_outlier"] is True)
         & (df["sv_ind_ptax_flag"] == 1),
         sv_is_heuristic_outlier=lambda df: (~df["sv_ind_ptax_flag"] == 1)
-        & (df["sv_is_outlier"] == True),
+        & (df["sv_is_outlier"] is True),
     )
 
     return df
@@ -300,7 +312,9 @@ def finish_flags(df, start_date, manual_update, sales_to_write_filter):
 
     if sales_to_write_filter["column"]:
         df = df[
-            df[sales_to_write_filter["column"]].isin(sales_to_write_filter["values"])
+            df[sales_to_write_filter["column"]].isin(
+                sales_to_write_filter["values"]
+            )
         ]
 
     cols_to_write = [
@@ -326,11 +340,13 @@ def finish_flags(df, start_date, manual_update, sales_to_write_filter):
     )
 
     adj_name_combo = (
-        np.random.choice(left["adjective"]) + "-" + np.random.choice(right["person"])
+        np.random.choice(left["adjective"])
+        + "-"
+        + np.random.choice(right["person"])
     )
-    timestamp = datetime.datetime.now(pytz.timezone("America/Chicago")).strftime(
-        "%Y-%m-%d_%H:%M"
-    )
+    timestamp = datetime.datetime.now(
+        pytz.timezone("America/Chicago")
+    ).strftime("%Y-%m-%d_%H:%M")
     run_id = timestamp + "-" + adj_name_combo
 
     # Control flow for incorporating versioning
@@ -567,5 +583,7 @@ def write_to_table(df, table_name, s3_warehouse_bucket_path, run_id):
         run_id: unique run_id of the script
     """
     file_name = run_id + ".parquet"
-    s3_file_path = os.path.join(s3_warehouse_bucket_path, "sale", table_name, file_name)
+    s3_file_path = os.path.join(
+        s3_warehouse_bucket_path, "sale", table_name, file_name
+    )
     wr.s3.to_parquet(df=df, path=s3_file_path)


### PR DESCRIPTION
Now that we've picked up active development of this repo again, it's bugging me that our linter isn't catching small style inconsistencies like sort order, line length, and boolean/null comparisons. This PR switches the linter to ruff, configures it to enforce the same rules we use in https://github.com/ccao-data/data-architecture/, and uses it to reformat the code. There shouldn't be any functional changes to the code as part of this PR, just a change to the way it's formatted.