### PR TITLE
Fix formatter bug and make code ruff compliant

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -498,7 +498,8 @@ def percent_change(df: pd.DataFrame) -> pd.DataFrame:
         df (pd.DataFrame): dataframe with CGR statistic and previous_price column
     """
 
-    original_df = df[df["original_observation"] is True].copy()
+    mask_original_df = df["original_observation"]
+    original_df = df.loc[mask_original_df].copy()
     original_df["sv_previous_price"] = (
         original_df.sort_values("meta_sale_date")
         .groupby(["pin"])["meta_sale_price"]
@@ -673,7 +674,8 @@ def transaction_days(df: pd.DataFrame) -> pd.DataFrame:
         df (pd.DataFrame): DataFrame with new column
     """
 
-    original_df = df[df["original_observation"] is True].copy()
+    mask_original_df = df["original_observation"]
+    original_df = df.loc[mask_original_df].copy()
     original_df["sv_days_since_last_transaction"] = (
         original_df.sort_values("meta_sale_date")
         .groupby("pin")["meta_sale_date"]

--- a/src/model.py
+++ b/src/model.py
@@ -673,8 +673,7 @@ def transaction_days(df: pd.DataFrame) -> pd.DataFrame:
         df (pd.DataFrame): DataFrame with new column
     """
 
-    mask_original_df = df["original_observation"]
-    original_df = df.loc[mask_original_df].copy()
+    original_df = df[df["original_observation"]].copy()
     original_df["sv_days_since_last_transaction"] = (
         original_df.sort_values("meta_sale_date")
         .groupby("pin")["meta_sale_date"]

--- a/src/model.py
+++ b/src/model.py
@@ -498,8 +498,7 @@ def percent_change(df: pd.DataFrame) -> pd.DataFrame:
         df (pd.DataFrame): dataframe with CGR statistic and previous_price column
     """
 
-    mask_original_df = df["original_observation"]
-    original_df = df.loc[mask_original_df].copy()
+    original_df = df[df["original_observation"]].copy()
     original_df["sv_previous_price"] = (
         original_df.sort_values("meta_sale_date")
         .groupby(["pin"])["meta_sale_price"]


### PR DESCRIPTION
Interestingly, with the merging of https://github.com/ccao-data/model-sales-val/pull/157, there was a bug introduced into the sales val pipeline.

Prior to the PR this subset was `original_df = df[df["original_observation"] == True].copy()` which checks elementwise

whereas the ruff introduced `original_df = df[df["original_observation"] is True].copy()` checks identity, which I believe was evaluating to a single `False` value, rather than subsetting the data by assigning booleans for every row, or something like that.

Upon reverting to the previous method, ruff complained, so I introduced a potentially more pythonic (pandas-onic?) solution that no longer throws a formatting error.

