### PR TITLE
Adjust default sales val south tri stat groupings to use custom defined nbhd groups

### DIFF
--- a/src/inputs.yaml
+++ b/src/inputs.yaml
@@ -4,7 +4,6 @@
 # Note included with each run. Use this to summarize what changed about the run
 # or add context
 run_note: |
-  Testing full run of south tri nbhd_groups edit
 
 # 'dev' or 'prod'
 output_environment: dev


### PR DESCRIPTION
Editing the input spec so that we set the[ recently custom built geographic groups](https://github.com/ccao-data/data-architecture/pull/971) to be the default for residential south tri flagging. These groups were built in collaboration with res val.